### PR TITLE
added mongoose connection logging and global error middleware

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,7 @@ coverage/
 
 # TypeScript
 *.tsbuildinfo
+
+.agent/
+.agents/
+issue.md

--- a/skills-lock.json
+++ b/skills-lock.json
@@ -1,0 +1,10 @@
+{
+  "version": 1,
+  "skills": {
+    "senior-backend": {
+      "source": "davila7/claude-code-templates",
+      "sourceType": "github",
+      "computedHash": "1919d688687239bae5880bd935ce8f845e7b4f82293faba882bb8e2cbb9481b6"
+    }
+  }
+}

--- a/src/infra/mongo/connection.ts
+++ b/src/infra/mongo/connection.ts
@@ -2,6 +2,7 @@ import mongoose from 'mongoose';
 
 export async function connectMongo(mongoUri: string) {
   await mongoose.connect(mongoUri);
+  console.log('MongoDB connected');
 }
 
 export async function disconnectMongo() {

--- a/src/shared/http/errorMiddleware.ts
+++ b/src/shared/http/errorMiddleware.ts
@@ -1,16 +1,47 @@
 import type { ErrorRequestHandler } from 'express';
+import mongoose from 'mongoose';
 import { AppError } from './errors.js';
 
 export function errorMiddleware(): ErrorRequestHandler {
   return (err, _req, res, _next) => {
-    if (err instanceof AppError) {
-      return res.status(err.statusCode).json({
-        error: { message: err.message, code: err.code },
+    const isDev = process.env.NODE_ENV !== 'production';
+
+    // Mongoose duplicate key error
+    if (err.code === 11000) {
+      const field = Object.keys(err.keyValue ?? {})[0] ?? 'field';
+      return res.status(400).json({
+        success: false,
+        message: `Duplicate value for ${field}.`,
+        ...(isDev && { stack: err.stack }),
       });
     }
 
+    // Mongoose validation error
+    if (err instanceof mongoose.Error.ValidationError) {
+      const message = Object.values(err.errors)
+        .map((e: mongoose.Error.ValidatorError | mongoose.Error.CastError) => e.message)
+        .join(', ');
+      return res.status(422).json({
+        success: false,
+        message,
+        ...(isDev && { stack: err.stack }),
+      });
+    }
+
+    // App-level operational errors
+    if (err instanceof AppError) {
+      return res.status(err.statusCode).json({
+        success: false,
+        message: err.message,
+        ...(isDev && { stack: err.stack }),
+      });
+    }
+
+    // Fallback
     return res.status(500).json({
-      error: { message: 'Internal Server Error' },
+      success: false,
+      message: 'Internal Server Error',
+      ...(isDev && { stack: err.stack }),
     });
   };
 }

--- a/tests/errorMiddleware.test.ts
+++ b/tests/errorMiddleware.test.ts
@@ -1,0 +1,86 @@
+import express, { type Request, type Response, type NextFunction } from 'express';
+import request from 'supertest';
+import mongoose from 'mongoose';
+import { errorMiddleware } from '../src/shared/http/errorMiddleware.js';
+import { AppError } from '../src/shared/http/errors.js';
+
+function buildTestApp(err: unknown) {
+  const app = express();
+  app.get('/test', (_req: Request, _res: Response, next: NextFunction) => next(err));
+  app.use(errorMiddleware());
+  return app;
+}
+
+describe('errorMiddleware', () => {
+  describe('AppError', () => {
+    it('returns the AppError status code and message', async () => {
+      const app = buildTestApp(new AppError(404, 'Not found'));
+      const res = await request(app).get('/test');
+      expect(res.status).toBe(404);
+      expect(res.body.success).toBe(false);
+      expect(res.body.message).toBe('Not found');
+    });
+  });
+
+  describe('Mongoose duplicate key error (11000)', () => {
+    it('maps to 400 and reports the duplicate field', async () => {
+      const dupErr = Object.assign(new Error('E11000 duplicate'), {
+        code: 11000,
+        keyValue: { email: 'test@test.com' },
+      });
+      const app = buildTestApp(dupErr);
+      const res = await request(app).get('/test');
+      expect(res.status).toBe(400);
+      expect(res.body.success).toBe(false);
+      expect(res.body.message).toContain('email');
+    });
+  });
+
+  describe('Mongoose ValidationError', () => {
+    it('maps to 422 and includes field messages', async () => {
+      const validationErr = new mongoose.Error.ValidationError();
+      validationErr.errors['name'] = new mongoose.Error.ValidatorError({
+        message: 'name is required',
+        path: 'name',
+        type: 'required',
+        value: undefined,
+      });
+      const app = buildTestApp(validationErr);
+      const res = await request(app).get('/test');
+      expect(res.status).toBe(422);
+      expect(res.body.success).toBe(false);
+      expect(res.body.message).toContain('name is required');
+    });
+  });
+
+  describe('unknown error', () => {
+    it('falls back to 500 Internal Server Error', async () => {
+      const app = buildTestApp(new Error('boom'));
+      const res = await request(app).get('/test');
+      expect(res.status).toBe(500);
+      expect(res.body.success).toBe(false);
+      expect(res.body.message).toBe('Internal Server Error');
+    });
+  });
+
+  describe('stack trace exposure', () => {
+    const originalEnv = process.env.NODE_ENV;
+    afterEach(() => {
+      process.env.NODE_ENV = originalEnv;
+    });
+
+    it('includes stack in non-production mode', async () => {
+      process.env.NODE_ENV = 'development';
+      const app = buildTestApp(new AppError(400, 'bad'));
+      const res = await request(app).get('/test');
+      expect(res.body.stack).toBeDefined();
+    });
+
+    it('omits stack in production mode', async () => {
+      process.env.NODE_ENV = 'production';
+      const app = buildTestApp(new AppError(400, 'bad'));
+      const res = await request(app).get('/test');
+      expect(res.body.stack).toBeUndefined();
+    });
+  });
+});


### PR DESCRIPTION
- Log "MongoDB connected" after successful mongoose.connect()
- Rewrite errorMiddleware to return { success: false, message, stack? }
  - Map Mongoose 11000 duplicate-key errors → 400
  - Map Mongoose ValidationError → 422
  - Expose stack trace only in non-production environments
- Add tests/errorMiddleware.test.ts with 6 unit tests covering all
  error branches and stack-trace exposure behaviour
closes: #2