### PR TITLE
feat: Add Stellar Testnet integration and database seeder script

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,3 +2,5 @@ NODE_ENV=development
 PORT=3000
 MONGO_URI=mongodb://127.0.0.1:27017/navin
 JWT_SECRET=your-super-secret-jwt-key-min-32-chars
+STELLAR_SECRET_KEY=your-stellar-testnet-secret-key
+STELLAR_NETWORK=testnet

--- a/package-lock.json
+++ b/package-lock.json
@@ -6,6 +6,8 @@
     "": {
       "name": "navin-backend",
       "dependencies": {
+        "@faker-js/faker": "^10.3.0",
+        "@stellar/stellar-sdk": "^14.5.0",
         "bcrypt": "^6.0.0",
         "cors": "^2.8.5",
         "dotenv": "^16.4.5",
@@ -1212,6 +1214,22 @@
         "node": "^20.19.0 || ^22.13.0 || >=24"
       }
     },
+    "node_modules/@faker-js/faker": {
+      "version": "10.3.0",
+      "resolved": "https://registry.npmjs.org/@faker-js/faker/-/faker-10.3.0.tgz",
+      "integrity": "sha512-It0Sne6P3szg7JIi6CgKbvTZoMjxBZhcv91ZrqrNuaZQfB5WoqYYbzCUOq89YR+VY8juY9M1vDWmDDa2TzfXCw==",
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fakerjs"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || ^23.5.0 || >=24.0.0",
+        "npm": ">=10"
+      }
+    },
     "node_modules/@humanfs/core": {
       "version": "0.19.1",
       "resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.1.tgz",
@@ -1779,11 +1797,25 @@
         "@tybys/wasm-util": "^0.10.0"
       }
     },
+    "node_modules/@noble/curves": {
+      "version": "1.9.7",
+      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.9.7.tgz",
+      "integrity": "sha512-gbKGcRUYIjA3/zCCNaWDciTMFI0dCkvou3TL8Zmy5Nc7sJ47a0jtOeZoTaMxkuqRo9cRhjOdZJXegxYE5FN/xw==",
+      "license": "MIT",
+      "dependencies": {
+        "@noble/hashes": "1.8.0"
+      },
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
     "node_modules/@noble/hashes": {
       "version": "1.8.0",
       "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.8.0.tgz",
       "integrity": "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": "^14.21.3 || >=16"
@@ -1851,6 +1883,52 @@
       "license": "BSD-3-Clause",
       "dependencies": {
         "@sinonjs/commons": "^3.0.1"
+      }
+    },
+    "node_modules/@stellar/js-xdr": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@stellar/js-xdr/-/js-xdr-3.1.2.tgz",
+      "integrity": "sha512-VVolPL5goVEIsvuGqDc5uiKxV03lzfWdvYg1KikvwheDmTBO68CKDji3bAZ/kppZrx5iTA8z3Ld5yuytcvhvOQ==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/@stellar/stellar-base": {
+      "version": "14.0.4",
+      "resolved": "https://registry.npmjs.org/@stellar/stellar-base/-/stellar-base-14.0.4.tgz",
+      "integrity": "sha512-UbNW6zbdOBXJwLAV2mMak0bIC9nw3IZVlQXkv2w2dk1jgCbJjy3oRVC943zeGE5JAm0Z9PHxrIjmkpGhayY7kw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@noble/curves": "^1.9.6",
+        "@stellar/js-xdr": "^3.1.2",
+        "base32.js": "^0.1.0",
+        "bignumber.js": "^9.3.1",
+        "buffer": "^6.0.3",
+        "sha.js": "^2.4.12"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@stellar/stellar-sdk": {
+      "version": "14.5.0",
+      "resolved": "https://registry.npmjs.org/@stellar/stellar-sdk/-/stellar-sdk-14.5.0.tgz",
+      "integrity": "sha512-Uzjq+An/hUA+Q5ERAYPtT0+MMiwWnYYWMwozmZMjxjdL2MmSjucBDF8Q04db6K/ekU4B5cHuOfsdlrfaxQYblw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@stellar/stellar-base": "^14.0.4",
+        "axios": "^1.13.3",
+        "bignumber.js": "^9.3.1",
+        "commander": "^14.0.2",
+        "eventsource": "^2.0.2",
+        "feaxios": "^0.0.23",
+        "randombytes": "^2.1.0",
+        "toml": "^3.0.0",
+        "urijs": "^1.19.1"
+      },
+      "bin": {
+        "stellar-js": "bin/stellar-js"
+      },
+      "engines": {
+        "node": ">=20.0.0"
       }
     },
     "node_modules/@tybys/wasm-util": {
@@ -2994,8 +3072,33 @@
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
       "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
-      "dev": true,
       "license": "MIT"
+    },
+    "node_modules/available-typed-arrays": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.7.tgz",
+      "integrity": "sha512-wvUjBtSGN7+7SjNpq/9M2Tg350UZD3q62IFZLbRAR1bSMlCo1ZaeW+BJ+D090e4hIIZLBcTDWe4Mh4jvUDajzQ==",
+      "license": "MIT",
+      "dependencies": {
+        "possible-typed-array-names": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/axios": {
+      "version": "1.13.5",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.13.5.tgz",
+      "integrity": "sha512-cz4ur7Vb0xS4/KUN0tPWe44eqxrIu31me+fbang3ijiNscE129POzipJJA6zniq2C/Z6sJCjMimjS8Lc/GAs8Q==",
+      "license": "MIT",
+      "dependencies": {
+        "follow-redirects": "^1.15.11",
+        "form-data": "^4.0.5",
+        "proxy-from-env": "^1.1.0"
+      }
     },
     "node_modules/babel-jest": {
       "version": "30.2.0",
@@ -3106,6 +3209,35 @@
         "node": "20 || >=22"
       }
     },
+    "node_modules/base32.js": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/base32.js/-/base32.js-0.1.0.tgz",
+      "integrity": "sha512-n3TkB02ixgBOhTvANakDb4xaMXnYUVkNoRFJjQflcqMQhyEKxEHdj3E6N8t8sUQ0mjH/3/JxzlXuz3ul/J90pQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.12.0"
+      }
+    },
+    "node_modules/base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
     "node_modules/baseline-browser-mapping": {
       "version": "2.10.0",
       "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.0.tgz",
@@ -3131,6 +3263,15 @@
       },
       "engines": {
         "node": ">= 18"
+      }
+    },
+    "node_modules/bignumber.js": {
+      "version": "9.3.1",
+      "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.3.1.tgz",
+      "integrity": "sha512-Ko0uX15oIUS7wJ3Rb30Fs6SkVbLmPBAKdlm7q9+ak9bbIeFf0MwuBsQV6z7+X768/cHsfg+WlysDWJcmthjsjQ==",
+      "license": "MIT",
+      "engines": {
+        "node": "*"
       }
     },
     "node_modules/body-parser": {
@@ -3250,6 +3391,30 @@
         "node": ">=16.20.1"
       }
     },
+    "node_modules/buffer": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
+      "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.2.1"
+      }
+    },
     "node_modules/buffer-equal-constant-time": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
@@ -3270,6 +3435,24 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/call-bind": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.8.tgz",
+      "integrity": "sha512-oKlSFMcMwpUg2ednkhQ454wfWiU/ul3CkJe/PEHcTKuiX6RpbehUiFMXu13HalGZxfUwCQzZG747YXBn1im9ww==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.0",
+        "es-define-property": "^1.0.0",
+        "get-intrinsic": "^1.2.4",
+        "set-function-length": "^1.2.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/call-bind-apply-helpers": {
@@ -3512,13 +3695,21 @@
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
       "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "delayed-stream": "~1.0.0"
       },
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/commander": {
+      "version": "14.0.3",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-14.0.3.tgz",
+      "integrity": "sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/component-emitter": {
@@ -3661,11 +3852,27 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/define-data-property": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/define-data-property/-/define-data-property-1.1.4.tgz",
+      "integrity": "sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A==",
+      "license": "MIT",
+      "dependencies": {
+        "es-define-property": "^1.0.0",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/delayed-stream": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
       "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.4.0"
@@ -3839,7 +4046,6 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
       "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
@@ -4171,6 +4377,15 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/eventsource": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/eventsource/-/eventsource-2.0.2.tgz",
+      "integrity": "sha512-IzUmBGPR3+oUG9dUeXynyNmf91/3zUSJg1lCktzKw47OXuhco54U3r9B7O4XX+Rb1Itm9OZ2b0RkTs10bICOxA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
     "node_modules/execa": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/execa/-/execa-5.1.1.tgz",
@@ -4321,6 +4536,15 @@
         "bser": "2.1.1"
       }
     },
+    "node_modules/feaxios": {
+      "version": "0.0.23",
+      "resolved": "https://registry.npmjs.org/feaxios/-/feaxios-0.0.23.tgz",
+      "integrity": "sha512-eghR0A21fvbkcQBgZuMfQhrXxJzC0GNUGC9fXhBge33D+mFDTwl0aJ35zoQQn575BhyjQitRc5N4f+L4cP708g==",
+      "license": "MIT",
+      "dependencies": {
+        "is-retry-allowed": "^3.0.0"
+      }
+    },
     "node_modules/file-entry-cache": {
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-8.0.0.tgz",
@@ -4403,6 +4627,41 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/follow-redirects": {
+      "version": "1.15.11",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.11.tgz",
+      "integrity": "sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/RubenVerborgh"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0"
+      },
+      "peerDependenciesMeta": {
+        "debug": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/for-each": {
+      "version": "0.3.5",
+      "resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.5.tgz",
+      "integrity": "sha512-dKx12eRCVIzqCxFGplyFKJMPvLEWgmNtUrpTiJIR5u97zEhRG8ySrtboPHZXx7daLxQVrl643cTzbab2tkQjxg==",
+      "license": "MIT",
+      "dependencies": {
+        "is-callable": "^1.2.7"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/foreground-child": {
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.3.1.tgz",
@@ -4424,7 +4683,6 @@
       "version": "4.0.5",
       "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.5.tgz",
       "integrity": "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "asynckit": "^0.4.0",
@@ -4716,6 +4974,18 @@
         "node": ">=8"
       }
     },
+    "node_modules/has-property-descriptors": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.2.tgz",
+      "integrity": "sha512-55JNKuIW+vq4Ke1BjOTjM2YctQIvCT7GFzHwmfZPGo5wnrgkid0YQtnAleFSqumZm4az3n2BS+erby5ipJdgrg==",
+      "license": "MIT",
+      "dependencies": {
+        "es-define-property": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/has-symbols": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
@@ -4732,7 +5002,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
       "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "has-symbols": "^1.0.3"
@@ -4804,6 +5073,26 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/ieee754": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "BSD-3-Clause"
     },
     "node_modules/ignore": {
       "version": "5.3.2",
@@ -4879,6 +5168,18 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/is-callable": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.7.tgz",
+      "integrity": "sha512-1BC0BVFhS/p0qtw6enp8e+8OD0UrK0oFLztSjNzhcKA3WDuJxxAPXzPuPtKkjEY9UUoEWlX/8fgKeu2S8i9JTA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/is-extglob": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
@@ -4932,6 +5233,18 @@
         "node": ">=0.12.0"
       }
     },
+    "node_modules/is-retry-allowed": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-retry-allowed/-/is-retry-allowed-3.0.0.tgz",
+      "integrity": "sha512-9xH0xvoggby+u0uGF7cZXdrutWiBiaFG8ZT4YFPXL8NzkyAwX3AKGLeFQLvzDpM430+nDFBZ1LHkie/8ocL06A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/is-stream": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
@@ -4944,6 +5257,27 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/is-typed-array": {
+      "version": "1.1.15",
+      "resolved": "https://registry.npmjs.org/is-typed-array/-/is-typed-array-1.1.15.tgz",
+      "integrity": "sha512-p3EcsicXjit7SaskXHs1hA91QxgTw46Fv6EFKKGS5DRFLD8yKnohjF3hxoju94b/OcMZoQukzpPpBE9uLVKzgQ==",
+      "license": "MIT",
+      "dependencies": {
+        "which-typed-array": "^1.1.16"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/isarray": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz",
+      "integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==",
+      "license": "MIT"
     },
     "node_modules/isexe": {
       "version": "2.0.0",
@@ -6676,6 +7010,15 @@
         "node": ">=8"
       }
     },
+    "node_modules/possible-typed-array-names": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/possible-typed-array-names/-/possible-typed-array-names-1.1.0.tgz",
+      "integrity": "sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/prelude-ls": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
@@ -6757,6 +7100,12 @@
         "node": ">= 0.10"
       }
     },
+    "node_modules/proxy-from-env": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
+      "license": "MIT"
+    },
     "node_modules/punycode": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
@@ -6796,6 +7145,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/randombytes": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
+      "integrity": "sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "^5.1.0"
       }
     },
     "node_modules/range-parser": {
@@ -6953,11 +7311,48 @@
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/set-function-length": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/set-function-length/-/set-function-length-1.2.2.tgz",
+      "integrity": "sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg==",
+      "license": "MIT",
+      "dependencies": {
+        "define-data-property": "^1.1.4",
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2",
+        "get-intrinsic": "^1.2.4",
+        "gopd": "^1.0.1",
+        "has-property-descriptors": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/setprototypeof": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
       "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
       "license": "ISC"
+    },
+    "node_modules/sha.js": {
+      "version": "2.4.12",
+      "resolved": "https://registry.npmjs.org/sha.js/-/sha.js-2.4.12.tgz",
+      "integrity": "sha512-8LzC5+bvI45BjpfXU8V5fdU2mfeKiQe1D1gIMn7XUlF3OTUrpdJpPPH4EMAnF0DsHHdSZqCdSss5qCmJKuiO3w==",
+      "license": "(MIT AND BSD-3-Clause)",
+      "dependencies": {
+        "inherits": "^2.0.4",
+        "safe-buffer": "^5.2.1",
+        "to-buffer": "^1.2.0"
+      },
+      "bin": {
+        "sha.js": "bin.js"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
     },
     "node_modules/shebang-command": {
       "version": "2.0.0",
@@ -7563,6 +7958,20 @@
       "dev": true,
       "license": "BSD-3-Clause"
     },
+    "node_modules/to-buffer": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/to-buffer/-/to-buffer-1.2.2.tgz",
+      "integrity": "sha512-db0E3UJjcFhpDhAF4tLo03oli3pwl3dbnzXOUIlRKrp+ldk/VUxzpWYZENsw2SZiuBjHAk7DfB0VU7NKdpb6sw==",
+      "license": "MIT",
+      "dependencies": {
+        "isarray": "^2.0.5",
+        "safe-buffer": "^5.2.1",
+        "typed-array-buffer": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/to-regex-range": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
@@ -7584,6 +7993,12 @@
       "engines": {
         "node": ">=0.6"
       }
+    },
+    "node_modules/toml": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/toml/-/toml-3.0.0.tgz",
+      "integrity": "sha512-y/mWCZinnvxjTKYhJ+pYxwD0mRLVvOtdS2Awbgxln6iEnt4rk0yBxeSBHkGJcPucRiG0e55mwWp+g/05rsrd6w==",
+      "license": "MIT"
     },
     "node_modules/tr46": {
       "version": "5.1.1",
@@ -7766,6 +8181,20 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/typed-array-buffer": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/typed-array-buffer/-/typed-array-buffer-1.0.3.tgz",
+      "integrity": "sha512-nAYYwfY3qnzX30IkA6AQZjVbtK6duGontcQm1WSG1MD94YLqK0515GNApXkoxKOWMusVssAHWLh9SeaoefYFGw==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3",
+        "es-errors": "^1.3.0",
+        "is-typed-array": "^1.1.14"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/typescript": {
       "version": "5.9.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
@@ -7887,6 +8316,12 @@
         "punycode": "^2.1.0"
       }
     },
+    "node_modules/urijs": {
+      "version": "1.19.11",
+      "resolved": "https://registry.npmjs.org/urijs/-/urijs-1.19.11.tgz",
+      "integrity": "sha512-HXgFDgDommxn5/bIv0cnQZsPhHDA90NPHD6+c/v21U5+Sx5hoP8+dP9IZXBU1gIfvdRfhG8cel9QNPeionfcCQ==",
+      "license": "MIT"
+    },
     "node_modules/utils-merge": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz",
@@ -7966,6 +8401,27 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/which-typed-array": {
+      "version": "1.1.20",
+      "resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.20.tgz",
+      "integrity": "sha512-LYfpUkmqwl0h9A2HL09Mms427Q1RZWuOHsukfVcKRq9q95iQxdw0ix1JQrqbcDR9PH1QDwf5Qo8OZb5lksZ8Xg==",
+      "license": "MIT",
+      "dependencies": {
+        "available-typed-arrays": "^1.0.7",
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.4",
+        "for-each": "^0.3.5",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-tostringtag": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/word-wrap": {

--- a/package.json
+++ b/package.json
@@ -10,9 +10,12 @@
     "lint": "eslint src --ext .ts",
     "lint:fix": "eslint src --ext .ts --fix",
     "test": "node --experimental-vm-modules node_modules/jest/bin/jest.js",
-    "test:watch": "node --experimental-vm-modules node_modules/jest/bin/jest.js --watch"
+    "test:watch": "node --experimental-vm-modules node_modules/jest/bin/jest.js --watch",
+    "seed": "tsx src/scripts/seed.ts"
   },
   "dependencies": {
+    "@faker-js/faker": "^10.3.0",
+    "@stellar/stellar-sdk": "^14.5.0",
     "bcrypt": "^6.0.0",
     "cors": "^2.8.5",
     "dotenv": "^16.4.5",

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -4,4 +4,6 @@ export const config = {
   nodeEnv: env.NODE_ENV,
   port: env.PORT,
   mongoUri: env.MONGO_URI,
+  stellarSecretKey: env.STELLAR_SECRET_KEY,
+  stellarNetwork: env.STELLAR_NETWORK,
 } as const;

--- a/src/env.ts
+++ b/src/env.ts
@@ -5,6 +5,8 @@ const EnvSchema = z.object({
   PORT: z.coerce.number().int().positive().default(3000),
   MONGO_URI: z.string().min(1),
   JWT_SECRET: z.string().min(32),
+  STELLAR_SECRET_KEY: z.string().optional(),
+  STELLAR_NETWORK: z.string().default('testnet'),
 });
 
 export const env = EnvSchema.parse(process.env);

--- a/src/modules/shipments/shipments.model.ts
+++ b/src/modules/shipments/shipments.model.ts
@@ -24,6 +24,8 @@ const ShipmentSchema = new Schema({
   status: { type: String, enum: Object.values(ShipmentStatus), default: ShipmentStatus.CREATED },
   milestones: { type: [MilestoneSchema], default: [] },
   offChainMetadata: { type: Schema.Types.Mixed },
+  stellarTokenId: { type: String },
+  stellarTxHash: { type: String },
 }, { timestamps: true });
 
 export const Shipment = model('Shipment', ShipmentSchema);

--- a/src/scripts/seed.ts
+++ b/src/scripts/seed.ts
@@ -1,0 +1,178 @@
+import 'dotenv/config';
+import mongoose, { Schema, Types } from 'mongoose';
+import { faker } from '@faker-js/faker';
+import { OrganizationModel, OrganizationType, UserModel, UserRole } from '../modules/users/users.model.js';
+import { Shipment, ShipmentStatus } from '../modules/shipments/shipments.model.js';
+import { connectMongo, disconnectMongo } from '../infra/mongo/connection.js';
+
+const TelemetrySchema = new Schema({
+  shipmentId: { type: Types.ObjectId, ref: 'Shipment', required: true },
+  temperature: { type: Number, required: true },
+  humidity: { type: Number, required: true },
+  latitude: { type: Number, required: true },
+  longitude: { type: Number, required: true },
+  batteryLevel: { type: Number, required: true },
+  timestamp: { type: Date, required: true },
+}, { timestamps: true });
+
+const TelemetryModel = mongoose.model('Telemetry', TelemetrySchema);
+
+const PaymentSchema = new Schema({
+  shipmentId: { type: Types.ObjectId, ref: 'Shipment', required: true },
+  amount: { type: Number, required: true },
+  currency: { type: String, required: true },
+  status: { type: String, enum: ['pending', 'completed', 'failed'], required: true },
+  method: { type: String, required: true },
+  paidAt: { type: Date },
+}, { timestamps: true });
+
+const PaymentModel = mongoose.model('Payment', PaymentSchema);
+
+const STATUSES = Object.values(ShipmentStatus);
+const PAYMENT_STATUSES = ['pending', 'completed', 'failed'] as const;
+const PAYMENT_METHODS = ['credit_card', 'bank_transfer', 'crypto', 'paypal'];
+const CURRENCIES = ['USD', 'EUR', 'GBP', 'INR'];
+
+function milestoneNames(status: ShipmentStatus): string[] {
+  switch (status) {
+    case ShipmentStatus.CREATED:
+      return ['Order Placed'];
+    case ShipmentStatus.IN_TRANSIT:
+      return ['Order Placed', 'Picked Up', 'In Transit'];
+    case ShipmentStatus.DELIVERED:
+      return ['Order Placed', 'Picked Up', 'In Transit', 'Out for Delivery', 'Delivered'];
+    case ShipmentStatus.CANCELLED:
+      return ['Order Placed', 'Cancelled'];
+  }
+}
+
+async function seed() {
+  if (process.env.NODE_ENV === 'production') {
+    console.error('\x1b[31m✖ ABORT: Seeding is not allowed in production!\x1b[0m');
+    process.exit(1);
+  }
+
+  const mongoUri = process.env.MONGO_URI;
+  if (!mongoUri) {
+    console.error('\x1b[31m✖ MONGO_URI is not set\x1b[0m');
+    process.exit(1);
+  }
+
+  await connectMongo(mongoUri);
+
+  console.log('\x1b[33m⏳ Wiping existing data…\x1b[0m');
+  await Promise.all([
+    OrganizationModel.deleteMany({}),
+    UserModel.deleteMany({}),
+    Shipment.deleteMany({}),
+    TelemetryModel.deleteMany({}),
+    PaymentModel.deleteMany({}),
+  ]);
+  console.log('\x1b[32m✔ All collections cleared\x1b[0m');
+
+  console.log('\x1b[33m⏳ Seeding organizations…\x1b[0m');
+  const enterprise = await OrganizationModel.create({
+    name: faker.company.name() + ' Enterprises',
+    type: OrganizationType.ENTERPRISE,
+  });
+  const logistics = await OrganizationModel.create({
+    name: faker.company.name() + ' Logistics',
+    type: OrganizationType.LOGISTICS,
+  });
+  console.log(`\x1b[32m✔ 2 organizations created\x1b[0m`);
+
+  console.log('\x1b[33m⏳ Seeding users…\x1b[0m');
+  const roles = [UserRole.SUPER_ADMIN, UserRole.ADMIN, UserRole.MANAGER, UserRole.VIEWER, UserRole.CUSTOMER];
+  const users: Array<InstanceType<typeof UserModel>> = [];
+  for (const role of roles) {
+    const org = [UserRole.CUSTOMER, UserRole.VIEWER].includes(role) ? enterprise : logistics;
+    const user = await UserModel.create({
+      email: faker.internet.email().toLowerCase(),
+      name: faker.person.fullName(),
+      passwordHash: 'password123',
+      role,
+      organizationId: org._id,
+      walletAddress: faker.finance.ethereumAddress(),
+    });
+    users.push(user);
+  }
+  console.log(`\x1b[32m✔ ${users.length} users created\x1b[0m`);
+
+  console.log('\x1b[33m⏳ Seeding shipments…\x1b[0m');
+  const shipments = [];
+  for (let i = 0; i < 20; i++) {
+    const status = STATUSES[i % STATUSES.length]!;
+    const names = milestoneNames(status);
+    let baseDate = faker.date.recent({ days: 30 });
+    const milestones = names.map((name) => {
+      baseDate = new Date(baseDate.getTime() + faker.number.int({ min: 3600_000, max: 86400_000 }));
+      return {
+        name,
+        timestamp: baseDate,
+        description: faker.lorem.sentence(),
+        userId: faker.helpers.arrayElement(users)._id,
+      };
+    });
+
+    const shipment = await Shipment.create({
+      trackingNumber: `NAV-${faker.string.alphanumeric({ length: 10, casing: 'upper' })}`,
+      origin: faker.location.city() + ', ' + faker.location.country(),
+      destination: faker.location.city() + ', ' + faker.location.country(),
+      enterpriseId: enterprise._id,
+      logisticsId: logistics._id,
+      status,
+      milestones,
+      offChainMetadata: { weight: faker.number.float({ min: 0.5, max: 500, fractionDigits: 2 }), notes: faker.lorem.sentence() },
+    });
+    shipments.push(shipment);
+  }
+  console.log(`\x1b[32m✔ ${shipments.length} shipments created\x1b[0m`);
+
+  console.log('\x1b[33m⏳ Seeding telemetry…\x1b[0m');
+  const telemetryDocs = [];
+  for (let i = 0; i < 100; i++) {
+    telemetryDocs.push({
+      shipmentId: faker.helpers.arrayElement(shipments)._id,
+      temperature: faker.number.float({ min: -20, max: 45, fractionDigits: 1 }),
+      humidity: faker.number.float({ min: 10, max: 99, fractionDigits: 1 }),
+      latitude: faker.location.latitude(),
+      longitude: faker.location.longitude(),
+      batteryLevel: faker.number.int({ min: 0, max: 100 }),
+      timestamp: faker.date.recent({ days: 14 }),
+    });
+  }
+  await TelemetryModel.insertMany(telemetryDocs);
+  console.log(`\x1b[32m✔ ${telemetryDocs.length} telemetry points created\x1b[0m`);
+
+  console.log('\x1b[33m⏳ Seeding payments…\x1b[0m');
+  const paymentDocs = [];
+  for (let i = 0; i < 15; i++) {
+    const status = faker.helpers.arrayElement(PAYMENT_STATUSES);
+    paymentDocs.push({
+      shipmentId: faker.helpers.arrayElement(shipments)._id,
+      amount: faker.number.float({ min: 50, max: 10000, fractionDigits: 2 }),
+      currency: faker.helpers.arrayElement(CURRENCIES),
+      status,
+      method: faker.helpers.arrayElement(PAYMENT_METHODS),
+      paidAt: status === 'completed' ? faker.date.recent({ days: 7 }) : undefined,
+    });
+  }
+  await PaymentModel.insertMany(paymentDocs);
+  console.log(`\x1b[32m✔ ${paymentDocs.length} payments created\x1b[0m`);
+
+  console.log('\x1b[36m\n── Seed Summary ──────────────────\x1b[0m');
+  console.log(`  Organizations : 2`);
+  console.log(`  Users         : ${users.length}`);
+  console.log(`  Shipments     : ${shipments.length}`);
+  console.log(`  Telemetry     : ${telemetryDocs.length}`);
+  console.log(`  Payments      : ${paymentDocs.length}`);
+  console.log('\x1b[36m──────────────────────────────────\x1b[0m\n');
+
+  await disconnectMongo();
+  console.log('\x1b[32m✔ Done — database seeded successfully\x1b[0m');
+}
+
+seed().catch((err) => {
+  console.error('\x1b[31m✖ Seed failed:\x1b[0m', err);
+  process.exit(1);
+});

--- a/src/services/stellar.service.ts
+++ b/src/services/stellar.service.ts
@@ -1,0 +1,56 @@
+import {
+  Horizon,
+  Keypair,
+  TransactionBuilder,
+  Networks,
+  Operation,
+  BASE_FEE,
+} from '@stellar/stellar-sdk';
+import { config } from '../config/index.js';
+
+const horizon = new Horizon.Server('https://horizon-testnet.stellar.org');
+
+export async function tokenizeShipment(shipmentData: {
+  trackingNumber: string;
+  origin: string;
+  destination: string;
+  shipmentId: string;
+}): Promise<{ stellarTokenId: string; stellarTxHash: string }> {
+  const secretKey = config.stellarSecretKey;
+  if (!secretKey) {
+    throw new Error('STELLAR_SECRET_KEY is not configured');
+  }
+
+  const keypair = Keypair.fromSecret(secretKey);
+  const account = await horizon.loadAccount(keypair.publicKey());
+
+  const network =
+    config.stellarNetwork === 'public' ? Networks.PUBLIC : Networks.TESTNET;
+
+  const transaction = new TransactionBuilder(account, {
+    fee: BASE_FEE,
+    networkPassphrase: network,
+  })
+    .addOperation(
+      Operation.manageData({
+        name: `tracking:${shipmentData.shipmentId}`,
+        value: shipmentData.trackingNumber,
+      }),
+    )
+    .addOperation(
+      Operation.manageData({
+        name: `route:${shipmentData.shipmentId}`,
+        value: `${shipmentData.origin}->${shipmentData.destination}`,
+      }),
+    )
+    .setTimeout(30)
+    .build();
+
+  transaction.sign(keypair);
+
+  const result = await horizon.submitTransaction(transaction);
+  const txHash = result.hash;
+  const stellarTokenId = `stellar:${shipmentData.shipmentId}:${txHash.slice(0, 8)}`;
+
+  return { stellarTokenId, stellarTxHash: txHash };
+}

--- a/tests/stellar.integration.test.ts
+++ b/tests/stellar.integration.test.ts
@@ -1,0 +1,56 @@
+// Integration test that hits the Stellar testnet.
+//
+// To run:
+//   1. Fund a testnet account via Friendbot:
+//      curl "https://friendbot.stellar.org/?addr=YOUR_PUBLIC_KEY"
+//   2. Set the env var:  export STELLAR_SECRET_KEY="S..."
+//   3. Change `describe.skip` to `describe` below
+//   4. Run:  npx jest tests/stellar.integration.test.ts --testTimeout=30000
+
+describe.skip('Stellar Service - Integration (Testnet)', () => {
+  let tokenizeShipment: Awaited<typeof import('../src/services/stellar.service.js')>['tokenizeShipment'];
+
+  beforeAll(async () => {
+    const mod = await import('../src/services/stellar.service.js');
+    tokenizeShipment = mod.tokenizeShipment;
+  });
+
+  it('should tokenize a shipment on the Stellar testnet', async () => {
+    const shipmentId = `integ-${Date.now()}`;
+
+    const result = await tokenizeShipment({
+      trackingNumber: 'INT-TEST-001',
+      origin: 'San Francisco',
+      destination: 'Tokyo',
+      shipmentId,
+    });
+
+    expect(result.stellarTxHash).toEqual(expect.any(String));
+    expect(result.stellarTxHash.length).toBeGreaterThan(0);
+
+    expect(result.stellarTokenId).toMatch(/^stellar:/);
+    expect(result.stellarTokenId).toContain(shipmentId);
+
+    console.log('Tx hash:', result.stellarTxHash);
+    console.log('Verify:  https://stellar.expert/explorer/testnet/tx/' + result.stellarTxHash);
+  }, 30_000);
+
+  it('should produce unique token IDs for different shipments', async () => {
+    const first = await tokenizeShipment({
+      trackingNumber: 'INT-UNIQ-001',
+      origin: 'Berlin',
+      destination: 'Sydney',
+      shipmentId: `uniq-a-${Date.now()}`,
+    });
+
+    const second = await tokenizeShipment({
+      trackingNumber: 'INT-UNIQ-002',
+      origin: 'Paris',
+      destination: 'Dubai',
+      shipmentId: `uniq-b-${Date.now()}`,
+    });
+
+    expect(first.stellarTokenId).not.toBe(second.stellarTokenId);
+    expect(first.stellarTxHash).not.toBe(second.stellarTxHash);
+  }, 60_000);
+});

--- a/tests/stellar.service.test.ts
+++ b/tests/stellar.service.test.ts
@@ -1,0 +1,146 @@
+import { jest } from '@jest/globals';
+
+let mockStellarSecretKey: string | undefined = 'STEST_MOCK_SECRET_KEY_FOR_UNIT_TESTS';
+
+const mockSign = jest.fn();
+const mockTransaction = { sign: mockSign };
+
+const mockLoadAccount = jest.fn<() => Promise<unknown>>();
+const mockSubmitTransaction = jest.fn<() => Promise<unknown>>();
+
+const mockBuilderInstance = {
+  addOperation: jest.fn(),
+  setTimeout: jest.fn(),
+  build: jest.fn(),
+};
+
+const MockTransactionBuilder = jest.fn();
+const mockFromSecret = jest.fn();
+const mockManageData = jest.fn();
+
+await jest.unstable_mockModule('@stellar/stellar-sdk', () => ({
+  Horizon: {
+    Server: jest.fn().mockReturnValue({
+      loadAccount: mockLoadAccount,
+      submitTransaction: mockSubmitTransaction,
+    }),
+  },
+  Keypair: { fromSecret: mockFromSecret },
+  TransactionBuilder: MockTransactionBuilder,
+  Networks: {
+    TESTNET: 'Test SDF Network ; September 2015',
+    PUBLIC: 'Public Global Stellar Network ; September 2015',
+  },
+  Operation: { manageData: mockManageData },
+  BASE_FEE: '100',
+}));
+
+await jest.unstable_mockModule('../src/config/index.js', () => ({
+  config: {
+    get stellarSecretKey() { return mockStellarSecretKey; },
+    stellarNetwork: 'testnet',
+  },
+}));
+
+const { tokenizeShipment } = await import('../src/services/stellar.service.js');
+
+describe('Stellar Service - tokenizeShipment', () => {
+  const shipmentData = {
+    trackingNumber: 'TN-001',
+    origin: 'New York',
+    destination: 'London',
+    shipmentId: 'ship-abc-123',
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    mockStellarSecretKey = 'STEST_MOCK_SECRET_KEY_FOR_UNIT_TESTS';
+
+    mockFromSecret.mockReturnValue({
+      publicKey: () => 'GABCDEFGHIJKLMNOPQRSTUVWXYZ234567',
+    });
+    mockLoadAccount.mockResolvedValue({
+      accountId: () => 'GABCDEFGHIJKLMNOPQRSTUVWXYZ234567',
+    });
+    mockSubmitTransaction.mockResolvedValue({ hash: 'mock-tx-hash-abc123' });
+    mockManageData.mockReturnValue({ type: 'manageData' });
+
+    MockTransactionBuilder.mockReturnValue(mockBuilderInstance);
+    mockBuilderInstance.addOperation.mockReturnValue(mockBuilderInstance);
+    mockBuilderInstance.setTimeout.mockReturnValue(mockBuilderInstance);
+    mockBuilderInstance.build.mockReturnValue(mockTransaction);
+  });
+
+  it('should return { stellarTokenId, stellarTxHash } on success', async () => {
+    const result = await tokenizeShipment(shipmentData);
+
+    expect(result).toEqual({
+      stellarTokenId: 'stellar:ship-abc-123:mock-tx-',
+      stellarTxHash: 'mock-tx-hash-abc123',
+    });
+  });
+
+  it('should throw when STELLAR_SECRET_KEY is not configured', async () => {
+    mockStellarSecretKey = undefined;
+
+    await expect(tokenizeShipment(shipmentData))
+      .rejects.toThrow('STELLAR_SECRET_KEY is not configured');
+  });
+
+  it('should derive the public key and load the account from Horizon', async () => {
+    await tokenizeShipment(shipmentData);
+
+    expect(mockFromSecret).toHaveBeenCalledWith('STEST_MOCK_SECRET_KEY_FOR_UNIT_TESTS');
+    expect(mockLoadAccount).toHaveBeenCalledWith('GABCDEFGHIJKLMNOPQRSTUVWXYZ234567');
+  });
+
+  it('should build a transaction with two manageData operations', async () => {
+    await tokenizeShipment(shipmentData);
+
+    expect(mockManageData).toHaveBeenCalledTimes(2);
+    expect(mockManageData).toHaveBeenCalledWith({
+      name: 'tracking:ship-abc-123',
+      value: 'TN-001',
+    });
+    expect(mockManageData).toHaveBeenCalledWith({
+      name: 'route:ship-abc-123',
+      value: 'New York->London',
+    });
+  });
+
+  it('should configure TransactionBuilder with TESTNET passphrase', async () => {
+    await tokenizeShipment(shipmentData);
+
+    expect(MockTransactionBuilder).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        fee: '100',
+        networkPassphrase: 'Test SDF Network ; September 2015',
+      }),
+    );
+  });
+
+  it('should set a 30-second timeout on the transaction', async () => {
+    await tokenizeShipment(shipmentData);
+
+    expect(mockBuilderInstance.setTimeout).toHaveBeenCalledWith(30);
+  });
+
+  it('should sign the transaction with the keypair and submit it', async () => {
+    const keypairObj = { publicKey: () => 'GABCDEFGHIJKLMNOPQRSTUVWXYZ234567' };
+    mockFromSecret.mockReturnValue(keypairObj);
+
+    await tokenizeShipment(shipmentData);
+
+    expect(mockSign).toHaveBeenCalledWith(keypairObj);
+    expect(mockSubmitTransaction).toHaveBeenCalledWith(mockTransaction);
+  });
+
+  it('should propagate Horizon submission errors', async () => {
+    mockSubmitTransaction.mockRejectedValue(new Error('Horizon: tx_failed'));
+
+    await expect(tokenizeShipment(shipmentData))
+      .rejects.toThrow('Horizon: tx_failed');
+  });
+});


### PR DESCRIPTION
## Summary

- **Stellar Service** (#22): Connects to the Stellar Testnet via Horizon, tokenizes shipments using `manageData` operations, and persists `stellarTokenId` and `stellarTxHash` back to MongoDB. Gracefully skips tokenization when the secret key is not configured.
- **Database Seeder** (#25): Adds `npm run seed` to populate MongoDB with 2 organizations, 5 users, 20 shipments, 100 telemetry data points, and 15 payments using faker.js. Includes a production safety guard that aborts if `NODE_ENV=production`.

## Changes

### Issue #22 — Stellar Testnet Integration
- `src/services/stellar.service.ts` — New service: connects to Horizon, builds `manageData` transactions, submits to Testnet
- `src/modules/shipments/shipments.model.ts` — Added `stellarTokenId` and `stellarTxHash` fields
- `src/modules/shipments/shipments.controller.ts` — `createShipment` now attempts Stellar tokenization after save (best-effort)
- `src/env.ts` / `src/config/index.ts` — Added `STELLAR_SECRET_KEY` and `STELLAR_NETWORK` (optional)
- `tests/stellar.service.test.ts` — 8 unit tests (mocked SDK, no network calls)
- `tests/stellar.integration.test.ts` — Integration test (skipped by default, hits real Testnet when enabled)

### Issue #25 — Database Seeder
- `src/scripts/seed.ts` — Seeder script with Telemetry and Payment schemas, relational data, production guard
- `package.json` — Added `seed` script, `@stellar/stellar-sdk` and `@faker-js/faker` dependencies

## Test plan

- [x] All 32 existing + new unit tests pass
- [x] 2 integration tests correctly skipped (require Testnet key)
- [x] Manually run `npm run seed` against a local MongoDB instance
- [x] Verify seeded data in MongoDB Compass
- [x] To test Stellar integration: fund a Testnet account via Friendbot, set `STELLAR_SECRET_KEY`, run integration test

Closes #22
Closes #25