### PR TITLE
feat: setup Redis connection and BullMQ queue service

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,7 @@
+services:
+  redis:
+    image: redis:7-alpine
+    container_name: navin_redis
+    ports:
+      - "6379:6379"
+    restart: unless-stopped

--- a/src/infra/redis/connection.ts
+++ b/src/infra/redis/connection.ts
@@ -1,0 +1,15 @@
+import Redis from 'ioredis';
+import { config } from '../../config/index.js';
+
+let redisClient: Redis | null = null;
+
+export function getRedisClient(): Redis {
+  if (!redisClient) {
+    redisClient = new Redis(config.redisUrl, {
+      maxRetriesPerRequest: null,
+    });
+  }
+  return redisClient;
+}
+
+export const redisConnection = getRedisClient();

--- a/src/services/__tests__/queue.service.test.ts
+++ b/src/services/__tests__/queue.service.test.ts
@@ -1,0 +1,36 @@
+import { jest, describe, it, expect, beforeEach } from '@jest/globals';
+
+const mockAdd = jest.fn().mockResolvedValue({});
+
+jest.unstable_mockModule('bullmq', () => ({
+  Queue: jest.fn().mockImplementation(() => ({ add: mockAdd })),
+}));
+
+jest.unstable_mockModule('../../infra/redis/connection.js', () => ({
+  redisConnection: {},
+}));
+
+describe('queue.service', () => {
+  let addJobToQueue: (name: string, payload: unknown) => Promise<void>;
+
+  beforeEach(async () => {
+    jest.clearAllMocks();
+    const mod = await import('../queue.service.js');
+    addJobToQueue = mod.addJobToQueue;
+  });
+
+  it('instantiates Queue with correct name', async () => {
+    const { Queue } = await import('bullmq');
+    expect(Queue).toHaveBeenCalledWith('transaction_queue', expect.any(Object));
+  });
+
+  it('calls queue.add with correct name and payload', async () => {
+    await addJobToQueue('process_transaction', { amount: 100 });
+    expect(mockAdd).toHaveBeenCalledWith('process_transaction', { amount: 100 });
+  });
+
+  it('handles empty payload', async () => {
+    await addJobToQueue('empty_job', {});
+    expect(mockAdd).toHaveBeenCalledWith('empty_job', {});
+  });
+});

--- a/src/services/queue.service.ts
+++ b/src/services/queue.service.ts
@@ -1,0 +1,10 @@
+import { Queue } from 'bullmq';
+import { redisConnection } from '../infra/redis/connection';
+
+const transactionQueue = new Queue('transaction_queue', {
+  connection: redisConnection,
+});
+
+export async function addJobToQueue(name: string, payload: unknown): Promise<void> {
+  await transactionQueue.add(name, payload);
+}


### PR DESCRIPTION
Closes #31 

Description:
Installs ioredis and bullmq. Creates a singleton Redis connection in src/infra/redis/connection.ts using config.redisUrl (consistent with existing codebase patterns) with maxRetriesPerRequest: null as required by BullMQ. Creates src/services/queue.service.ts with a transaction_queue and exported addJobToQueue(name, payload) helper. Adds docker-compose.yml with a local Redis container for development. Note: used REDIS_URL (not REDIS_URI as stated in the issue) to stay consistent with the existing .env.example and validated env schema.
Testing:

3 tests added in src/services/__tests__/queue.service.test.ts
3 passed, 0 failed
Covers: Queue instantiation, job add with payload, empty payload

Checklist:

 Branch named issue#31
 Docker Compose updated with Redis container
 Screenshot of passing Jest terminal logs attached
<img width="893" height="245" alt="Screenshot 2026-03-26 020239" src="https://github.com/user-attachments/assets/69f76e39-9151-4759-a88d-63d2a7b06624" />
