### PR TITLE
Implement API Key Auth for IoT Webhooks (#30)

### DIFF
--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -3,6 +3,212 @@ info:
   title: Navin Backend API
   version: 1.0.0
 paths:
+  /api/webhooks/iot:
+    post:
+      summary: IoT webhook endpoint for telemetry data
+      description: Receives telemetry data from IoT sensors. Requires API key authentication.
+      security:
+        - apiKeyAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required:
+                - shipmentId
+                - temperature
+                - humidity
+                - latitude
+                - longitude
+                - batteryLevel
+                - timestamp
+              properties:
+                shipmentId:
+                  type: string
+                  description: MongoDB ObjectId of the shipment
+                temperature:
+                  type: number
+                  description: Temperature in Celsius
+                humidity:
+                  type: number
+                  description: Humidity percentage
+                latitude:
+                  type: number
+                  description: GPS latitude
+                longitude:
+                  type: number
+                  description: GPS longitude
+                batteryLevel:
+                  type: number
+                  description: Battery level percentage
+                timestamp:
+                  type: string
+                  format: date-time
+                  description: Timestamp of the telemetry reading
+      responses:
+        '201':
+          description: Telemetry data received and processed
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  data:
+                    type: object
+                    properties:
+                      _id:
+                        type: string
+                      shipmentId:
+                        type: string
+                      temperature:
+                        type: number
+                      humidity:
+                        type: number
+                      latitude:
+                        type: number
+                      longitude:
+                        type: number
+                      batteryLevel:
+                        type: number
+                      timestamp:
+                        type: string
+                        format: date-time
+                      dataHash:
+                        type: string
+                      stellarTxHash:
+                        type: string
+        '400':
+          description: Invalid request payload
+        '401':
+          description: Missing or invalid API key
+  /api/auth/api-keys:
+    post:
+      summary: Create a new API key
+      description: Generates a new API key for machine-to-machine authentication. The raw API key is returned only once.
+      security:
+        - bearerAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required:
+                - name
+                - organizationId
+              properties:
+                name:
+                  type: string
+                  description: Descriptive name for the API key
+                organizationId:
+                  type: string
+                  description: MongoDB ObjectId of the organization
+                shipmentId:
+                  type: string
+                  description: Optional MongoDB ObjectId of a specific shipment
+      responses:
+        '201':
+          description: API key created successfully
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  message:
+                    type: string
+                  data:
+                    type: object
+                    properties:
+                      apiKey:
+                        type: string
+                        description: Raw API key (shown only once)
+                      id:
+                        type: string
+                      name:
+                        type: string
+                      organizationId:
+                        type: string
+                      shipmentId:
+                        type: string
+                      createdAt:
+                        type: string
+                        format: date-time
+        '400':
+          description: Invalid request
+        '401':
+          description: Unauthorized
+  /api/auth/api-keys/{organizationId}:
+    get:
+      summary: List API keys for an organization
+      description: Returns all active API keys for the specified organization (without exposing the raw keys)
+      security:
+        - bearerAuth: []
+      parameters:
+        - in: path
+          name: organizationId
+          required: true
+          schema:
+            type: string
+          description: MongoDB ObjectId of the organization
+      responses:
+        '200':
+          description: List of API keys
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  data:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        _id:
+                          type: string
+                        name:
+                          type: string
+                        organizationId:
+                          type: string
+                        shipmentId:
+                          type: string
+                        isActive:
+                          type: boolean
+                        lastUsedAt:
+                          type: string
+                          format: date-time
+                        createdAt:
+                          type: string
+                          format: date-time
+        '401':
+          description: Unauthorized
+  /api/auth/api-keys/{apiKeyId}:
+    delete:
+      summary: Revoke an API key
+      description: Deactivates an API key, preventing it from being used for authentication
+      security:
+        - bearerAuth: []
+      parameters:
+        - in: path
+          name: apiKeyId
+          required: true
+          schema:
+            type: string
+          description: MongoDB ObjectId of the API key
+      responses:
+        '200':
+          description: API key revoked successfully
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  message:
+                    type: string
+        '401':
+          description: Unauthorized
+        '404':
+          description: API key not found
   /api/analytics/performance:
     get:
       summary: Get analytics performance dashboard
@@ -148,3 +354,8 @@ securitySchemes:
   bearerAuth:
     type: http
     scheme: bearer
+  apiKeyAuth:
+    type: apiKey
+    in: header
+    name: x-api-key
+    description: API key for IoT device authentication

--- a/package-lock.json
+++ b/package-lock.json
@@ -77,6 +77,7 @@
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -2447,6 +2448,7 @@
       "integrity": "sha512-IgSWvLobTDOjnaxAfDTIHaECbkNlAlKv2j5SjpB2v7QHKv1FIfjwMy8FsDbVfDX/KjmCmYICcw7uGaXLhtsLNg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.56.0",
         "@typescript-eslint/types": "8.56.0",
@@ -3073,6 +3075,7 @@
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -3377,6 +3380,7 @@
       "integrity": "sha512-riJjyv1/mHLIPX4RwiK+oW9/4c3TEUeORHKefKAKnZ5kyslbN+HXowtbaVEqt4IMUB7OXlfixcs6gsFeo/jhiQ==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "peerDependencies": {
         "bare-abort-controller": "*"
       },
@@ -3612,6 +3616,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -4563,6 +4568,7 @@
       "integrity": "sha512-O0piBKY36YSJhlFSG8p9VUdPV/SxxS4FYDWVpr/9GJuMaepzwlf4J8I4ov1b+ySQfDTPhc3DtLaxcT1fN0yqCg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.2",
@@ -4619,6 +4625,7 @@
       "integrity": "sha512-82GZUjRS0p/jganf6q1rEO25VSoHH0hKPCTrgillPjdI/3bgBhAE1QzHrHTizjpRvy6pGAvKjDJtk2pF9NDq8w==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "eslint-config-prettier": "bin/cli.js"
       },
@@ -4887,6 +4894,7 @@
       "resolved": "https://registry.npmjs.org/express/-/express-4.22.1.tgz",
       "integrity": "sha512-F2X8g9P1X7uCPZMA3MVf9wcTqlyNp7IhH5qPCI0izhaOIYXaW9L535tGA3qmjRzpH+bZczqq7hVKxTR4NWnu+g==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "accepts": "~1.3.8",
         "array-flatten": "1.1.1",
@@ -6008,6 +6016,7 @@
       "integrity": "sha512-F26gjC0yWN8uAA5m5Ss8ZQf5nDHWGlN/xWZIh8S5SRbsEKBovwZhxGd6LJlbZYxBgCYOtreSUyb8hpXyGC5O4A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@jest/core": "30.2.0",
         "@jest/types": "30.2.0",
@@ -7852,6 +7861,7 @@
       "integrity": "sha512-UOnG6LftzbdaHZcKoPFtOcCKztrQ57WkHDeRD9t/PTQtmT0NHSeWWepj6pS0z/N7+08BHFDQVUrfmfMRcZwbMg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "prettier": "bin/prettier.cjs"
       },
@@ -8972,6 +8982,7 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -9233,6 +9244,7 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"

--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
     "lint:fix": "eslint src --ext .ts --fix",
     "test": "node --experimental-vm-modules node_modules/jest/bin/jest.js",
     "test:watch": "node --experimental-vm-modules node_modules/jest/bin/jest.js --watch",
-    "seed": "tsx src/scripts/seed.ts"
+    "seed": "tsx src/scripts/seed.ts",
+    "generate-api-key": "tsx src/scripts/generateApiKey.ts"
   },
   "dependencies": {
     "@faker-js/faker": "^10.3.0",

--- a/src/modules/auth/apiKey.controller.ts
+++ b/src/modules/auth/apiKey.controller.ts
@@ -1,0 +1,42 @@
+import type { RequestHandler } from 'express';
+import { generateApiKey, revokeApiKey, listApiKeys } from './apiKey.service.js';
+import { AppError } from '../../shared/http/errors.js';
+
+export const createApiKeyController: RequestHandler = async (req, res) => {
+  const { name, organizationId, shipmentId } = req.body;
+
+  if (!name || !organizationId) {
+    throw new AppError(400, 'name and organizationId are required', 'VALIDATION_ERROR');
+  }
+
+  const result = await generateApiKey({ name, organizationId, shipmentId });
+
+  res.status(201).json({
+    message: 'API key created successfully. Save this key securely - it will not be shown again.',
+    data: result,
+  });
+};
+
+export const listApiKeysController: RequestHandler = async (req, res) => {
+  const { organizationId } = req.params;
+
+  if (!organizationId) {
+    throw new AppError(400, 'organizationId is required', 'VALIDATION_ERROR');
+  }
+
+  const apiKeys = await listApiKeys(organizationId);
+
+  res.status(200).json({ data: apiKeys });
+};
+
+export const revokeApiKeyController: RequestHandler = async (req, res) => {
+  const { apiKeyId } = req.params;
+
+  if (!apiKeyId) {
+    throw new AppError(400, 'apiKeyId is required', 'VALIDATION_ERROR');
+  }
+
+  await revokeApiKey(apiKeyId);
+
+  res.status(200).json({ message: 'API key revoked successfully' });
+};

--- a/src/modules/auth/apiKey.model.ts
+++ b/src/modules/auth/apiKey.model.ts
@@ -1,0 +1,21 @@
+import mongoose, { type InferSchemaType } from 'mongoose';
+import bcrypt from 'bcrypt';
+
+const ApiKeySchema = new mongoose.Schema(
+  {
+    name: { type: String, required: true },
+    keyHash: { type: String, required: true, unique: true },
+    organizationId: { type: mongoose.Schema.Types.ObjectId, ref: 'Organization', required: true },
+    shipmentId: { type: mongoose.Schema.Types.ObjectId, ref: 'Shipment', required: false },
+    isActive: { type: Boolean, default: true },
+    lastUsedAt: { type: Date },
+  },
+  { timestamps: true }
+);
+
+ApiKeySchema.index({ keyHash: 1 });
+ApiKeySchema.index({ organizationId: 1 });
+ApiKeySchema.index({ shipmentId: 1 });
+
+export type ApiKey = InferSchemaType<typeof ApiKeySchema> & { _id: mongoose.Types.ObjectId };
+export const ApiKeyModel = mongoose.model<ApiKey>('ApiKey', ApiKeySchema);

--- a/src/modules/auth/apiKey.service.ts
+++ b/src/modules/auth/apiKey.service.ts
@@ -1,0 +1,90 @@
+import crypto from 'crypto';
+import bcrypt from 'bcrypt';
+import { ApiKeyModel } from './apiKey.model.js';
+import { AppError } from '../../shared/http/errors.js';
+
+interface CreateApiKeyParams {
+  name: string;
+  organizationId: string;
+  shipmentId?: string;
+}
+
+interface CreateApiKeyResult {
+  apiKey: string;
+  id: string;
+  name: string;
+  organizationId: string;
+  shipmentId?: string;
+  createdAt: Date;
+}
+
+export async function generateApiKey(params: CreateApiKeyParams): Promise<CreateApiKeyResult> {
+  // Generate a secure random API key (32 bytes = 64 hex characters)
+  const rawApiKey = crypto.randomBytes(32).toString('hex');
+  
+  // Hash the API key before storing
+  const salt = await bcrypt.genSalt(10);
+  const keyHash = await bcrypt.hash(rawApiKey, salt);
+
+  const apiKeyDoc = await ApiKeyModel.create({
+    name: params.name,
+    keyHash,
+    organizationId: params.organizationId,
+    shipmentId: params.shipmentId,
+    isActive: true,
+  });
+
+  // Return the raw API key only once - it will never be shown again
+  return {
+    apiKey: rawApiKey,
+    id: apiKeyDoc._id.toString(),
+    name: apiKeyDoc.name,
+    organizationId: apiKeyDoc.organizationId.toString(),
+    shipmentId: apiKeyDoc.shipmentId?.toString(),
+    createdAt: apiKeyDoc.createdAt,
+  };
+}
+
+export async function validateApiKey(rawApiKey: string): Promise<{
+  isValid: boolean;
+  apiKeyDoc?: any;
+}> {
+  if (!rawApiKey) {
+    return { isValid: false };
+  }
+
+  // Find all active API keys and check against the hash
+  const apiKeys = await ApiKeyModel.find({ isActive: true });
+
+  for (const apiKeyDoc of apiKeys) {
+    const isMatch = await bcrypt.compare(rawApiKey, apiKeyDoc.keyHash);
+    if (isMatch) {
+      // Update last used timestamp
+      await ApiKeyModel.updateOne(
+        { _id: apiKeyDoc._id },
+        { lastUsedAt: new Date() }
+      );
+      
+      return { isValid: true, apiKeyDoc };
+    }
+  }
+
+  return { isValid: false };
+}
+
+export async function revokeApiKey(apiKeyId: string): Promise<void> {
+  const result = await ApiKeyModel.updateOne(
+    { _id: apiKeyId },
+    { isActive: false }
+  );
+
+  if (result.matchedCount === 0) {
+    throw new AppError(404, 'API key not found', 'NOT_FOUND');
+  }
+}
+
+export async function listApiKeys(organizationId: string) {
+  return ApiKeyModel.find({ organizationId, isActive: true })
+    .select('-keyHash')
+    .sort({ createdAt: -1 });
+}

--- a/src/modules/auth/auth.routes.ts
+++ b/src/modules/auth/auth.routes.ts
@@ -1,10 +1,17 @@
 import { Router } from 'express';
 import { asyncHandler } from '../../shared/http/asyncHandler.js';
 import { validate } from '../../shared/validation/validate.js';
+import { requireAuth } from '../../shared/middleware/requireAuth.js';
 import { SignupBodySchema, LoginBodySchema } from './auth.validation.js';
 import { signupController, loginController } from './auth.controller.js';
+import { createApiKeyController, listApiKeysController, revokeApiKeyController } from './apiKey.controller.js';
 
 export const authRouter = Router();
 
 authRouter.post('/signup', validate({ body: SignupBodySchema }), asyncHandler(signupController));
 authRouter.post('/login', validate({ body: LoginBodySchema }), asyncHandler(loginController));
+
+// API Key management routes (protected by JWT auth)
+authRouter.post('/api-keys', asyncHandler(requireAuth), asyncHandler(createApiKeyController));
+authRouter.get('/api-keys/:organizationId', asyncHandler(requireAuth), asyncHandler(listApiKeysController));
+authRouter.delete('/api-keys/:apiKeyId', asyncHandler(requireAuth), asyncHandler(revokeApiKeyController));

--- a/src/modules/webhooks/iot.routes.ts
+++ b/src/modules/webhooks/iot.routes.ts
@@ -2,10 +2,16 @@ import { Router } from 'express';
 
 import { validate } from '../../shared/validation/validate.js';
 import { asyncHandler } from '../../shared/http/asyncHandler.js';
+import { requireApiKey } from '../../shared/middleware/requireApiKey.js';
 import { IotWebhookBodySchema } from './iot.validation.js';
 import { iotWebhookController } from './iot.controller.js';
 
 export const webhooksRouter = Router();
 
-webhooksRouter.post('/iot', validate({ body: IotWebhookBodySchema }), asyncHandler(iotWebhookController));
+webhooksRouter.post(
+  '/iot',
+  asyncHandler(requireApiKey),
+  validate({ body: IotWebhookBodySchema }),
+  asyncHandler(iotWebhookController)
+);
 

--- a/src/scripts/generateApiKey.ts
+++ b/src/scripts/generateApiKey.ts
@@ -1,0 +1,51 @@
+import '../loadEnv.js';
+import mongoose from 'mongoose';
+import { generateApiKey } from '../modules/auth/apiKey.service.js';
+import { config } from '../config/index.js';
+
+async function main() {
+  const args = process.argv.slice(2);
+  
+  if (args.length < 2) {
+    console.error('Usage: npm run generate-api-key <name> <organizationId> [shipmentId]');
+    console.error('Example: npm run generate-api-key "IoT Sensor 1" 507f1f77bcf86cd799439011');
+    process.exit(1);
+  }
+
+  const [name, organizationId, shipmentId] = args;
+
+  try {
+    await mongoose.connect(config.mongoUri);
+    console.log('Connected to MongoDB');
+
+    const result = await generateApiKey({
+      name,
+      organizationId,
+      shipmentId,
+    });
+
+    console.log('\n✅ API Key Generated Successfully!\n');
+    console.log('━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━');
+    console.log('⚠️  IMPORTANT: Save this API key securely - it will not be shown again!');
+    console.log('━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\n');
+    console.log(`API Key:        ${result.apiKey}`);
+    console.log(`ID:             ${result.id}`);
+    console.log(`Name:           ${result.name}`);
+    console.log(`Organization:   ${result.organizationId}`);
+    if (result.shipmentId) {
+      console.log(`Shipment:       ${result.shipmentId}`);
+    }
+    console.log(`Created:        ${result.createdAt.toISOString()}`);
+    console.log('\n━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\n');
+    console.log('Usage: Include this header in your IoT webhook requests:');
+    console.log(`x-api-key: ${result.apiKey}\n`);
+
+  } catch (error) {
+    console.error('Error generating API key:', error);
+    process.exit(1);
+  } finally {
+    await mongoose.disconnect();
+  }
+}
+
+main();

--- a/src/shared/middleware/requireApiKey.ts
+++ b/src/shared/middleware/requireApiKey.ts
@@ -1,0 +1,45 @@
+import type { RequestHandler } from 'express';
+import { AppError } from '../http/errors.js';
+import { validateApiKey } from '../../modules/auth/apiKey.service.js';
+
+declare global {
+  namespace Express {
+    interface Request {
+      apiKey?: {
+        id: string;
+        organizationId: string;
+        shipmentId?: string;
+      };
+    }
+  }
+}
+
+export const requireApiKey: RequestHandler = async (req, res, next) => {
+  const apiKey = req.headers['x-api-key'] as string;
+
+  if (!apiKey) {
+    throw new AppError(401, 'Missing x-api-key header', 'UNAUTHORIZED');
+  }
+
+  try {
+    const { isValid, apiKeyDoc } = await validateApiKey(apiKey);
+
+    if (!isValid || !apiKeyDoc) {
+      throw new AppError(401, 'Invalid API key', 'UNAUTHORIZED');
+    }
+
+    // Attach API key metadata to request
+    req.apiKey = {
+      id: apiKeyDoc._id.toString(),
+      organizationId: apiKeyDoc.organizationId.toString(),
+      shipmentId: apiKeyDoc.shipmentId?.toString(),
+    };
+
+    next();
+  } catch (error) {
+    if (error instanceof AppError) {
+      throw error;
+    }
+    throw new AppError(401, 'Invalid API key', 'UNAUTHORIZED');
+  }
+};

--- a/tests/apiKey.service.test.ts
+++ b/tests/apiKey.service.test.ts
@@ -1,0 +1,197 @@
+import { describe, expect, beforeEach, it, jest, afterEach, afterAll } from '@jest/globals';
+import { MongoMemoryServer } from 'mongodb-memory-server';
+import mongoose from 'mongoose';
+import { generateApiKey, validateApiKey, revokeApiKey, listApiKeys } from '../src/modules/auth/apiKey.service.js';
+import { ApiKeyModel } from '../src/modules/auth/apiKey.model.js';
+
+describe('API Key Service', () => {
+  let mongoServer: MongoMemoryServer;
+
+  beforeEach(async () => {
+    if (mongoose.connection.readyState !== 0) {
+      await mongoose.disconnect();
+    }
+    mongoServer = await MongoMemoryServer.create();
+    const uri = mongoServer.getUri();
+    await mongoose.connect(uri);
+    await ApiKeyModel.deleteMany({});
+  });
+
+  afterEach(async () => {
+    await mongoose.disconnect();
+    await mongoServer.stop();
+  });
+
+  describe('generateApiKey', () => {
+    it('generates a secure API key and stores hashed version', async () => {
+      const result = await generateApiKey({
+        name: 'Test API Key',
+        organizationId: '507f1f77bcf86cd799439011',
+      });
+
+      expect(result.apiKey).toBeDefined();
+      expect(result.apiKey).toHaveLength(64); // 32 bytes = 64 hex chars
+      expect(result.id).toBeDefined();
+      expect(result.name).toBe('Test API Key');
+      expect(result.organizationId).toBe('507f1f77bcf86cd799439011');
+      expect(result.createdAt).toBeInstanceOf(Date);
+
+      // Verify the raw key is not stored in database
+      const storedKey = await ApiKeyModel.findById(result.id);
+      expect(storedKey).toBeDefined();
+      expect(storedKey!.keyHash).not.toBe(result.apiKey);
+      expect(storedKey!.keyHash).toHaveLength(60); // bcrypt hash length
+    });
+
+    it('generates API key with shipmentId', async () => {
+      const result = await generateApiKey({
+        name: 'Shipment API Key',
+        organizationId: '507f1f77bcf86cd799439011',
+        shipmentId: '507f1f77bcf86cd799439012',
+      });
+
+      expect(result.shipmentId).toBe('507f1f77bcf86cd799439012');
+
+      const storedKey = await ApiKeyModel.findById(result.id);
+      expect(storedKey!.shipmentId?.toString()).toBe('507f1f77bcf86cd799439012');
+    });
+
+    it('generates unique API keys', async () => {
+      const result1 = await generateApiKey({
+        name: 'Key 1',
+        organizationId: '507f1f77bcf86cd799439011',
+      });
+
+      const result2 = await generateApiKey({
+        name: 'Key 2',
+        organizationId: '507f1f77bcf86cd799439011',
+      });
+
+      expect(result1.apiKey).not.toBe(result2.apiKey);
+      expect(result1.id).not.toBe(result2.id);
+    });
+  });
+
+  describe('validateApiKey', () => {
+    it('validates correct API key', async () => {
+      const { apiKey } = await generateApiKey({
+        name: 'Valid Key',
+        organizationId: '507f1f77bcf86cd799439011',
+      });
+
+      const result = await validateApiKey(apiKey);
+
+      expect(result.isValid).toBe(true);
+      expect(result.apiKeyDoc).toBeDefined();
+      expect(result.apiKeyDoc!.name).toBe('Valid Key');
+    });
+
+    it('rejects invalid API key', async () => {
+      await generateApiKey({
+        name: 'Valid Key',
+        organizationId: '507f1f77bcf86cd799439011',
+      });
+
+      const result = await validateApiKey('invalid-key-12345');
+
+      expect(result.isValid).toBe(false);
+      expect(result.apiKeyDoc).toBeUndefined();
+    });
+
+    it('rejects empty API key', async () => {
+      const result = await validateApiKey('');
+
+      expect(result.isValid).toBe(false);
+      expect(result.apiKeyDoc).toBeUndefined();
+    });
+
+    it('updates lastUsedAt timestamp on successful validation', async () => {
+      const { apiKey, id } = await generateApiKey({
+        name: 'Test Key',
+        organizationId: '507f1f77bcf86cd799439011',
+      });
+
+      const beforeValidation = await ApiKeyModel.findById(id);
+      expect(beforeValidation!.lastUsedAt).toBeUndefined();
+
+      await validateApiKey(apiKey);
+
+      const afterValidation = await ApiKeyModel.findById(id);
+      expect(afterValidation!.lastUsedAt).toBeInstanceOf(Date);
+    });
+
+    it('rejects inactive API key', async () => {
+      const { apiKey, id } = await generateApiKey({
+        name: 'Inactive Key',
+        organizationId: '507f1f77bcf86cd799439011',
+      });
+
+      await ApiKeyModel.updateOne({ _id: id }, { isActive: false });
+
+      const result = await validateApiKey(apiKey);
+
+      expect(result.isValid).toBe(false);
+    });
+  });
+
+  describe('revokeApiKey', () => {
+    it('revokes an active API key', async () => {
+      const { id, apiKey } = await generateApiKey({
+        name: 'To Revoke',
+        organizationId: '507f1f77bcf86cd799439011',
+      });
+
+      await revokeApiKey(id);
+
+      const revokedKey = await ApiKeyModel.findById(id);
+      expect(revokedKey!.isActive).toBe(false);
+
+      // Verify it can no longer be used
+      const result = await validateApiKey(apiKey);
+      expect(result.isValid).toBe(false);
+    });
+
+    it('throws error when API key not found', async () => {
+      await expect(revokeApiKey('507f1f77bcf86cd799439099')).rejects.toThrow('API key not found');
+    });
+  });
+
+  describe('listApiKeys', () => {
+    it('lists active API keys for organization', async () => {
+      const orgId = '507f1f77bcf86cd799439011';
+
+      await generateApiKey({ name: 'Key 1', organizationId: orgId });
+      await generateApiKey({ name: 'Key 2', organizationId: orgId });
+      await generateApiKey({ name: 'Other Org Key', organizationId: '507f1f77bcf86cd799439012' });
+
+      const keys = await listApiKeys(orgId);
+
+      expect(keys).toHaveLength(2);
+      expect(keys[0].name).toBe('Key 2'); // Most recent first
+      expect(keys[1].name).toBe('Key 1');
+    });
+
+    it('does not include revoked keys', async () => {
+      const orgId = '507f1f77bcf86cd799439011';
+
+      const { id } = await generateApiKey({ name: 'Active Key', organizationId: orgId });
+      const { id: revokedId } = await generateApiKey({ name: 'Revoked Key', organizationId: orgId });
+
+      await revokeApiKey(revokedId);
+
+      const keys = await listApiKeys(orgId);
+
+      expect(keys).toHaveLength(1);
+      expect(keys[0].name).toBe('Active Key');
+    });
+
+    it('does not expose keyHash', async () => {
+      const orgId = '507f1f77bcf86cd799439011';
+      await generateApiKey({ name: 'Key 1', organizationId: orgId });
+
+      const keys = await listApiKeys(orgId);
+
+      expect(keys[0].toObject()).not.toHaveProperty('keyHash');
+    });
+  });
+});

--- a/tests/iot.webhook.test.ts
+++ b/tests/iot.webhook.test.ts
@@ -23,6 +23,7 @@ describe('POST /api/webhooks/iot', () => {
   let app: any;
   const mockAnchorTelemetryHash: any = jest.fn();
   const mockTelemetryCreate: any = jest.fn();
+  const mockValidateApiKey: any = jest.fn();
 
   beforeEach(async () => {
     jest.clearAllMocks();
@@ -43,6 +44,15 @@ describe('POST /api/webhooks/iot', () => {
       rawPayload: parsedBodyForHash,
     });
 
+    mockValidateApiKey.mockResolvedValue({
+      isValid: true,
+      apiKeyDoc: {
+        _id: 'key123',
+        organizationId: 'org456',
+        shipmentId: body.shipmentId,
+      },
+    });
+
     await jest.unstable_mockModule('../src/modules/telemetry/telemetry.model.js', () => {
       return {
         Telemetry: {
@@ -61,6 +71,15 @@ describe('POST /api/webhooks/iot', () => {
       };
     });
 
+    await jest.unstable_mockModule('../src/modules/auth/apiKey.service.js', () => {
+      return {
+        validateApiKey: mockValidateApiKey,
+        generateApiKey: jest.fn(),
+        revokeApiKey: jest.fn(),
+        listApiKeys: jest.fn(),
+      };
+    });
+
     const appModule = await import('../src/app.js');
     app = appModule.buildApp();
   });
@@ -68,9 +87,11 @@ describe('POST /api/webhooks/iot', () => {
   it('hashes payload, anchors hash via Stellar, and saves txHash + dataHash', async () => {
     const res = await request(app)
       .post('/api/webhooks/iot')
+      .set('x-api-key', 'valid-api-key-12345')
       .send(body);
 
     expect(res.status).toBe(201);
+    expect(mockValidateApiKey).toHaveBeenCalledWith('valid-api-key-12345');
     expect(mockAnchorTelemetryHash).toHaveBeenCalledWith({
       shipmentId: body.shipmentId,
       dataHash,
@@ -103,9 +124,35 @@ describe('POST /api/webhooks/iot', () => {
     );
   });
 
+  it('returns 401 when x-api-key header is missing', async () => {
+    const res = await request(app)
+      .post('/api/webhooks/iot')
+      .send(body);
+
+    expect(res.status).toBe(401);
+    expect(res.body.message).toBe('Missing x-api-key header');
+    expect(mockValidateApiKey).not.toHaveBeenCalled();
+  });
+
+  it('returns 401 when API key is invalid', async () => {
+    mockValidateApiKey.mockResolvedValue({
+      isValid: false,
+    });
+
+    const res = await request(app)
+      .post('/api/webhooks/iot')
+      .set('x-api-key', 'invalid-api-key')
+      .send(body);
+
+    expect(res.status).toBe(401);
+    expect(res.body.message).toBe('Invalid API key');
+    expect(mockValidateApiKey).toHaveBeenCalledWith('invalid-api-key');
+  });
+
   it('returns 400 on invalid payload (validation error)', async () => {
     const res = await request(app)
       .post('/api/webhooks/iot')
+      .set('x-api-key', 'valid-api-key-12345')
       .send({
         ...body,
         temperature: 'not-a-number',

--- a/tests/requireApiKey.test.ts
+++ b/tests/requireApiKey.test.ts
@@ -1,0 +1,134 @@
+import { describe, expect, beforeEach, it, jest } from '@jest/globals';
+import request from 'supertest';
+import express from 'express';
+import { AppError } from '../src/shared/http/errors.js';
+
+const mockValidateApiKey = jest.fn();
+
+describe('requireApiKey middleware', () => {
+  let app: express.Application;
+
+  beforeEach(async () => {
+    jest.clearAllMocks();
+
+    // Mock the apiKey service
+    await jest.unstable_mockModule('../src/modules/auth/apiKey.service.js', () => ({
+      validateApiKey: mockValidateApiKey,
+    }));
+
+    // Import requireApiKey after mocking
+    const { requireApiKey: requireApiKeyMiddleware } = await import('../src/shared/middleware/requireApiKey.js');
+
+    app = express();
+    app.use(express.json());
+    
+    app.get('/test', async (req, res, next) => {
+      try {
+        await requireApiKeyMiddleware(req, res, next);
+      } catch (error) {
+        next(error);
+      }
+    }, (req, res) => {
+      res.status(200).json({ 
+        success: true,
+        apiKey: req.apiKey,
+      });
+    });
+
+    // Error handler
+    app.use((err: any, req: any, res: any, next: any) => {
+      if (err instanceof AppError) {
+        res.status(err.statusCode).json({ message: err.message, code: err.code });
+      } else {
+        res.status(500).json({ message: 'Internal Server Error' });
+      }
+    });
+  });
+
+  it('allows access with valid API key', async () => {
+    const mockApiKeyDoc = {
+      _id: 'key123',
+      organizationId: 'org456',
+      shipmentId: 'ship789',
+    };
+
+    mockValidateApiKey.mockResolvedValue({
+      isValid: true,
+      apiKeyDoc: mockApiKeyDoc,
+    });
+
+    const res = await request(app)
+      .get('/test')
+      .set('x-api-key', 'valid-api-key-12345');
+
+    expect(res.status).toBe(200);
+    expect(res.body.success).toBe(true);
+    expect(res.body.apiKey).toEqual({
+      id: 'key123',
+      organizationId: 'org456',
+      shipmentId: 'ship789',
+    });
+    expect(mockValidateApiKey).toHaveBeenCalledWith('valid-api-key-12345');
+  });
+
+  it('returns 401 when x-api-key header is missing', async () => {
+    const res = await request(app).get('/test');
+
+    expect(res.status).toBe(401);
+    expect(res.body.message).toBe('Missing x-api-key header');
+    expect(res.body.code).toBe('UNAUTHORIZED');
+    expect(mockValidateApiKey).not.toHaveBeenCalled();
+  });
+
+  it('returns 401 when API key is invalid', async () => {
+    mockValidateApiKey.mockResolvedValue({
+      isValid: false,
+    });
+
+    const res = await request(app)
+      .get('/test')
+      .set('x-api-key', 'invalid-api-key');
+
+    expect(res.status).toBe(401);
+    expect(res.body.message).toBe('Invalid API key');
+    expect(res.body.code).toBe('UNAUTHORIZED');
+    expect(mockValidateApiKey).toHaveBeenCalledWith('invalid-api-key');
+  });
+
+  it('returns 401 when validateApiKey throws an error', async () => {
+    mockValidateApiKey.mockRejectedValue(new Error('Database error'));
+
+    const res = await request(app)
+      .get('/test')
+      .set('x-api-key', 'some-key');
+
+    expect(res.status).toBe(401);
+    expect(res.body.message).toBe('Invalid API key');
+    expect(res.body.code).toBe('UNAUTHORIZED');
+  });
+
+  it('allows access with valid API key without shipmentId', async () => {
+    const mockApiKeyDoc = {
+      _id: 'key123',
+      organizationId: 'org456',
+    };
+
+    mockValidateApiKey.mockResolvedValue({
+      isValid: true,
+      apiKeyDoc: mockApiKeyDoc,
+    });
+
+    const res = await request(app)
+      .get('/test')
+      .set('x-api-key', 'valid-api-key-no-shipment');
+
+    expect(res.status).toBe(200);
+    expect(res.body.success).toBe(true);
+    expect(res.body.apiKey).toEqual({
+      id: 'key123',
+      organizationId: 'org456',
+      shipmentId: undefined,
+    });
+  });
+});
+


### PR DESCRIPTION
- Add secure API key generation using crypto.randomBytes(32)
- Store only bcrypt hashes in MongoDB, never raw keys
- Implement requireApiKey middleware for x-api-key header validation
- Protect POST /api/webhooks/iot with API key authentication
- Add API key management endpoints (create, list, revoke)
- Add comprehensive unit tests (18 new tests, all passing)
- Update Swagger/OpenAPI spec with API key documentation
- Add CLI tool for generating API keys (npm run generate-api-key)

All acceptance criteria met:
✅ Secure API key generation
✅ Raw keys returned only once, hashes stored
✅ requireApiKey middleware validates against database ✅ IoT webhook route protected
✅ Unit tests verify access control (106 tests passing) ✅ Swagger spec updated

Closes #30 