### PR TITLE
feat(infra): implement docker healthchecks (#101)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,19 @@
+FROM node:20-alpine
+
+WORKDIR /app
+
+# Install dependencies
+COPY package*.json ./
+RUN npm install
+
+# Copy source code
+COPY . .
+
+# Expose the API port
+EXPOSE 3000
+
+# Native Docker healthcheck querying the health endpoint
+HEALTHCHECK --interval=30s --timeout=10s --start-period=10s --retries=3 \
+  CMD wget --no-verbose --tries=1 --spider http://localhost:3000/api/health || exit 1
+
+CMD ["npm", "start"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,3 +5,18 @@ services:
     ports:
       - "6379:6379"
     restart: unless-stopped
+
+  backend:
+    build: .
+    container_name: navin_backend
+    ports:
+      - "3000:3000"
+    depends_on:
+      - redis
+    # Compose-level healthcheck mapping to the same endpoint
+    healthcheck:
+      test: ["CMD", "wget", "--no-verbose", "--tries=1", "--spider", "http://localhost:3000/api/health"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 10s


### PR DESCRIPTION
Closes #101

### **Description**
This PR implements native Docker healthchecks for the backend application, ensuring load balancers and orchestrators can accurately determine container readiness rather than just checking if the process is running.

### **Changes**
* **Dockerfile**: Created a base `Dockerfile` and appended the `HEALTHCHECK` instruction to periodically ping the `GET /api/health` endpoint using `wget`.
* **Docker Compose**: Added the `backend` service to `docker-compose.yml` and configured the corresponding `healthcheck` block to map to the same health endpoint.

### **Acceptance Criteria Progress**
- [x] Container status shows as `healthy` or `unhealthy` rather than just `running`.