### PR TITLE
Quality/extract mongoose interfaces

### DIFF
--- a/src/modules/anomaly/anomaly.model.ts
+++ b/src/modules/anomaly/anomaly.model.ts
@@ -1,17 +1,6 @@
 import { Schema, Types, model } from 'mongoose';
 import { isoDatePlugin } from '../../shared/plugins/isoDatePlugin.js';
-
-export const ANOMALY_SEVERITIES = ['LOW', 'MEDIUM', 'HIGH'] as const;
-export type AnomalySeverity = (typeof ANOMALY_SEVERITIES)[number];
-
-export const ANOMALY_TYPES = [
-  'TEMPERATURE_EXCEEDED',
-  'TEMPERATURE_BELOW_MIN',
-  'HUMIDITY_EXCEEDED',
-  'HUMIDITY_BELOW_MIN',
-  'BATTERY_LOW',
-] as const;
-export type AnomalyType = (typeof ANOMALY_TYPES)[number];
+import { IAnomaly, AnomalySeverity, AnomalyType, ANOMALY_SEVERITIES, ANOMALY_TYPES } from '../../shared/types/anomaly.js';
 
 const AnomalySchema = new Schema(
   {
@@ -32,4 +21,4 @@ AnomalySchema.index({ resolved: 1, timestamp: -1, _id: -1 });
 AnomalySchema.index({ severity: 1, timestamp: -1, _id: -1 });
 AnomalySchema.index({ severity: 1, shipmentId: 1, timestamp: -1, _id: -1 });
 
-export const Anomaly = model('Anomaly', AnomalySchema);
+export const Anomaly = model<IAnomaly>('Anomaly', AnomalySchema);

--- a/src/modules/auth/apiKey.model.ts
+++ b/src/modules/auth/apiKey.model.ts
@@ -1,5 +1,6 @@
 import mongoose, { type InferSchemaType } from 'mongoose';
 import { isoDatePlugin } from '../../shared/plugins/isoDatePlugin.js';
+import { IApiKey } from '../../shared/types/apiKey.js';
 
 const ApiKeySchema = new mongoose.Schema(
   {
@@ -19,5 +20,4 @@ ApiKeySchema.index({ keyHash: 1 });
 ApiKeySchema.index({ organizationId: 1 });
 ApiKeySchema.index({ shipmentId: 1 });
 
-export type ApiKey = InferSchemaType<typeof ApiKeySchema> & { _id: mongoose.Types.ObjectId };
-export const ApiKeyModel = mongoose.model<ApiKey>('ApiKey', ApiKeySchema);
+export const ApiKeyModel = mongoose.model<IApiKey>('ApiKey', ApiKeySchema);

--- a/src/modules/shipments/shipments.model.ts
+++ b/src/modules/shipments/shipments.model.ts
@@ -1,12 +1,6 @@
 import { Schema, model, Types } from 'mongoose';
 import { isoDatePlugin } from '../../shared/plugins/isoDatePlugin.js';
-
-export enum ShipmentStatus {
-  CREATED = 'CREATED',
-  IN_TRANSIT = 'IN_TRANSIT',
-  DELIVERED = 'DELIVERED',
-  CANCELLED = 'CANCELLED',
-}
+import { IShipment, ShipmentStatus } from '../../shared/types/shipment.js';
 
 const MilestoneSchema = new Schema({
   name: { type: String, required: true },
@@ -56,4 +50,4 @@ ShipmentSchema.pre('aggregate', function () {
   this.pipeline().unshift({ $match: { deletedAt: null } });
 });
 
-export const Shipment = model('Shipment', ShipmentSchema);
+export const Shipment = model<IShipment>('Shipment', ShipmentSchema);

--- a/src/modules/shipments/shipments.service.ts
+++ b/src/modules/shipments/shipments.service.ts
@@ -1,17 +1,18 @@
-import { Shipment, ShipmentStatus } from './shipments.model.js';
+import { Shipment } from './shipments.model.js';
 import type { FilterQuery } from 'mongoose';
 import { tokenizeShipment } from '../../services/stellar.service.js';
 import { mockUploadToStorage } from '../../services/mockStorageService.js';
 import { UserModel } from '../users/users.model.js';
 import { emitStatusUpdate } from '../../infra/socket/io.js';
+import { IShipment } from '../../shared/types/shipment.js';
 
 type ShipmentListResult = {
-  data: Awaited<ReturnType<typeof findShipments>>;
+  data: IShipment[];
   nextCursor: string | null;
   hasMore: boolean;
 };
 
-export const findShipments = async (query: FilterQuery<unknown>, limit: number) => {
+export const findShipments = async (query: FilterQuery<unknown>, limit: number): Promise<IShipment[]> => {
   return Shipment.find(query)
     .sort({ createdAt: -1, _id: -1 })
     .limit(limit + 1)

--- a/src/modules/telemetry/telemetry.model.ts
+++ b/src/modules/telemetry/telemetry.model.ts
@@ -1,11 +1,6 @@
 import { Schema, Types, model } from 'mongoose';
 import { isoDatePlugin } from '../../shared/plugins/isoDatePlugin.js';
-
-export enum TelemetryAnchorStatus {
-  PENDING_ANCHOR = 'PENDING_ANCHOR',
-  ANCHORED = 'ANCHORED',
-  ANCHOR_FAILED = 'ANCHOR_FAILED',
-}
+import { ITelemetry, TelemetryAnchorStatus } from '../../shared/types/telemetry.js';
 
 const TelemetrySchema = new Schema(
   {
@@ -43,4 +38,4 @@ TelemetrySchema.plugin(isoDatePlugin);
 TelemetrySchema.index({ shipmentId: 1, timestamp: -1 });
 TelemetrySchema.index({ anchorStatus: 1 });
 
-export const Telemetry = model('Telemetry', TelemetrySchema);
+export const Telemetry = model<ITelemetry>('Telemetry', TelemetrySchema);

--- a/src/modules/users/users.model.ts
+++ b/src/modules/users/users.model.ts
@@ -1,11 +1,7 @@
 import mongoose, { type InferSchemaType } from 'mongoose';
 import bcrypt from 'bcrypt';
 import { isoDatePlugin } from '../../shared/plugins/isoDatePlugin.js';
-
-export enum OrganizationType {
-  ENTERPRISE = 'ENTERPRISE',
-  LOGISTICS = 'LOGISTICS',
-}
+import { IOrganization, OrganizationType, IUser, UserRole } from '../../shared/types/user.js';
 
 const OrganizationSchema = new mongoose.Schema(
   {
@@ -74,10 +70,6 @@ UserSchema.pre('aggregate', function () {
   this.pipeline().unshift({ $match: { deletedAt: null } });
 });
 
-export type Organization = InferSchemaType<typeof OrganizationSchema> & {
-  _id: mongoose.Types.ObjectId;
-};
-export const OrganizationModel = mongoose.model<Organization>('Organization', OrganizationSchema);
+export const OrganizationModel = mongoose.model<IOrganization>('Organization', OrganizationSchema);
 
-export type User = InferSchemaType<typeof UserSchema> & { _id: mongoose.Types.ObjectId };
-export const UserModel = mongoose.model<User>('User', UserSchema);
+export const UserModel = mongoose.model<IUser>('User', UserSchema);

--- a/src/scripts/seed.ts
+++ b/src/scripts/seed.ts
@@ -3,11 +3,11 @@ import mongoose, { Schema, Types } from 'mongoose';
 import { faker } from '@faker-js/faker';
 import {
   OrganizationModel,
-  OrganizationType,
   UserModel,
-  UserRole,
 } from '../modules/users/users.model.js';
-import { Shipment, ShipmentStatus } from '../modules/shipments/shipments.model.js';
+import { OrganizationType, UserRole } from '../shared/types/user.js';
+import { Shipment } from '../modules/shipments/shipments.model.js';
+import { ShipmentStatus } from '../shared/types/shipment.js';
 import { connectMongo, disconnectMongo } from '../infra/mongo/connection.js';
 import { env } from '../env.js';
 

--- a/src/shared/types/anomaly.ts
+++ b/src/shared/types/anomaly.ts
@@ -1,0 +1,23 @@
+export const ANOMALY_SEVERITIES = ['LOW', 'MEDIUM', 'HIGH'] as const;
+export type AnomalySeverity = (typeof ANOMALY_SEVERITIES)[number];
+
+export const ANOMALY_TYPES = [
+  'TEMPERATURE_EXCEEDED',
+  'TEMPERATURE_BELOW_MIN',
+  'HUMIDITY_EXCEEDED',
+  'HUMIDITY_BELOW_MIN',
+  'BATTERY_LOW',
+] as const;
+export type AnomalyType = (typeof ANOMALY_TYPES)[number];
+
+export interface IAnomaly {
+  _id: string;
+  shipmentId: string;
+  type: AnomalyType;
+  severity: AnomalySeverity;
+  message: string;
+  timestamp: Date;
+  resolved: boolean;
+  createdAt: Date;
+  updatedAt: Date;
+}

--- a/src/shared/types/apiKey.ts
+++ b/src/shared/types/apiKey.ts
@@ -1,0 +1,11 @@
+export interface IApiKey {
+  _id: string;
+  name: string;
+  keyHash: string;
+  organizationId: string;
+  shipmentId?: string;
+  isActive: boolean;
+  lastUsedAt?: Date;
+  createdAt: Date;
+  updatedAt: Date;
+}

--- a/src/shared/types/shipment.ts
+++ b/src/shared/types/shipment.ts
@@ -1,0 +1,31 @@
+export interface IMilestone {
+  name: string;
+  timestamp: Date;
+  description?: string;
+  userId?: string;
+  walletAddress?: string;
+}
+
+export interface IDeliveryProof {
+  url: string;
+  recipientSignatureName: string;
+  uploadedAt: Date;
+}
+
+export interface IShipment {
+  _id: string;
+  trackingNumber: string;
+  origin: string;
+  destination: string;
+  enterpriseId: string;
+  logisticsId: string;
+  status: ShipmentStatus;
+  milestones: IMilestone[];
+  offChainMetadata?: Record<string, unknown>;
+  stellarTokenId?: string;
+  stellarTxHash?: string;
+  deliveryProof?: IDeliveryProof;
+  deletedAt?: Date;
+  createdAt: Date;
+  updatedAt: Date;
+}

--- a/src/shared/types/telemetry.ts
+++ b/src/shared/types/telemetry.ts
@@ -1,0 +1,24 @@
+export enum TelemetryAnchorStatus {
+  PENDING_ANCHOR = 'PENDING_ANCHOR',
+  ANCHORED = 'ANCHORED',
+  ANCHOR_FAILED = 'ANCHOR_FAILED',
+}
+
+export interface ITelemetry {
+  _id: string;
+  sensorId?: string;
+  shipmentId: string;
+  temperature: number;
+  humidity: number;
+  latitude: number;
+  longitude: number;
+  batteryLevel: number;
+  timestamp: Date;
+  dataHash: string;
+  stellarTxHash?: string;
+  anchorStatus: TelemetryAnchorStatus;
+  anchorError?: string;
+  rawPayload: Record<string, unknown>;
+  createdAt: Date;
+  updatedAt: Date;
+}

--- a/src/shared/types/user.ts
+++ b/src/shared/types/user.ts
@@ -1,0 +1,33 @@
+export enum OrganizationType {
+  ENTERPRISE = 'ENTERPRISE',
+  LOGISTICS = 'LOGISTICS',
+}
+
+export interface IOrganization {
+  _id: string;
+  name: string;
+  type: OrganizationType;
+  createdAt: Date;
+  updatedAt: Date;
+}
+
+export enum UserRole {
+  SUPER_ADMIN = 'SUPER_ADMIN',
+  ADMIN = 'ADMIN',
+  MANAGER = 'MANAGER',
+  VIEWER = 'VIEWER',
+  CUSTOMER = 'CUSTOMER',
+}
+
+export interface IUser {
+  _id: string;
+  email: string;
+  name: string;
+  passwordHash: string;
+  role: UserRole;
+  organizationId: string;
+  walletAddress?: string;
+  deletedAt?: Date;
+  createdAt: Date;
+  updatedAt: Date;
+}


### PR DESCRIPTION
Summary
Extract Mongoose document interfaces from schema files into `src/shared/types` to decouple business logic from Mongoose.

Changes
- Created shared interfaces in `src/shared/types`
- Updated models to use the extracted interfaces
- Updated services to reference `IShipment`, `IUser`, `ITelemetry`, etc. without importing Mongoose
- Adjusted related enum and type imports

Result
Services can now reference interfaces without depending on Mongoose directly, improving modularity and maintainability.

Closes #92

