### PR TITLE
security: enforce strict 100kb JSON/urlencoded payload limits globally

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -27,7 +27,8 @@ export function buildApp() {
   app.use(requestId());
   app.use(corsMiddleware);
   app.options('*', corsPreflight);
-  app.use(express.json());
+  app.use(express.json({ limit: '100kb' }));
+  app.use(express.urlencoded({ extended: true, limit: '100kb' }));
 
   app.use(standardLimiter);
   app.use('/api/auth/login', loginLimiter);

--- a/src/modules/webhooks/iot.routes.ts
+++ b/src/modules/webhooks/iot.routes.ts
@@ -1,4 +1,4 @@
-import { Router } from 'express';
+import express, { Router } from 'express';
 
 import { validate } from '../../shared/validation/validate.js';
 import { asyncHandler } from '../../shared/http/asyncHandler.js';
@@ -10,6 +10,7 @@ export const webhooksRouter = Router();
 
 webhooksRouter.post(
   '/iot',
+  express.json({ limit: '1mb' }),
   asyncHandler(requireApiKey),
   validate({ body: IotWebhookBodySchema }),
   asyncHandler(iotWebhookController)

--- a/tests/payload-limits.test.ts
+++ b/tests/payload-limits.test.ts
@@ -1,0 +1,17 @@
+import request from 'supertest';
+import { buildApp } from '../src/app.js';
+
+const app = buildApp();
+
+describe('Payload Limits', () => {
+  it('rejects JSON payloads over 100kb on standard routes', async () => {
+    const bigPayload = { data: 'x'.repeat(110 * 1024) };
+
+    const res = await request(app)
+      .post('/api/auth/signup')
+      .set('Content-Type', 'application/json')
+      .send(JSON.stringify(bigPayload));
+
+    expect(res.status).toBe(413);
+  });
+});


### PR DESCRIPTION
closes #105
  
  PR Description:
  
  │ Configures `express.json({ limit: '100kb' })` and `express.urlencoded({ extended: true, limit: '100kb' })` globally in `buildApp()`. The IoT webhook
  route (`POST /api/webhooks/iot`) gets a dedicated `express.json({ limit: '1mb' })` override to accommodate larger telemetry payloads. Oversized requests
  are rejected with `413 Payload Too Large`. Integration test added.
  
  