### PR TITLE
Implement Redis-based JWT revocation blocklist on logout

### DIFF
--- a/src/infra/redis/tokenBlocklist.ts
+++ b/src/infra/redis/tokenBlocklist.ts
@@ -1,0 +1,14 @@
+import { getRedisClient } from './connection.js';
+
+const BLOCKLIST_PREFIX = 'jwt:blocklist:';
+
+export async function blockToken(jti: string, ttlSeconds: number): Promise<void> {
+  const client = getRedisClient() as import('ioredis').Redis;
+  await client.set(`${BLOCKLIST_PREFIX}${jti}`, '1', 'EX', ttlSeconds);
+}
+
+export async function isTokenBlocked(jti: string): Promise<boolean> {
+  const client = getRedisClient() as import('ioredis').Redis;
+  const result = await client.exists(`${BLOCKLIST_PREFIX}${jti}`);
+  return result === 1;
+}

--- a/src/modules/auth/auth.controller.ts
+++ b/src/modules/auth/auth.controller.ts
@@ -1,5 +1,5 @@
 import type { RequestHandler } from 'express';
-import { signup, login } from './auth.service.js';
+import { signup, login, logout } from './auth.service.js';
 import { sendResponse } from '../../shared/http/sendResponse.js';
 
 export const signupController: RequestHandler = async (req, res) => {
@@ -10,4 +10,10 @@ export const signupController: RequestHandler = async (req, res) => {
 export const loginController: RequestHandler = async (req, res) => {
   const result = await login(req.body);
   sendResponse(res, 200, true, 'Login successful', result);
+};
+
+export const logoutController: RequestHandler = async (req, res) => {
+  const token = req.headers.authorization!.substring(7);
+  await logout(token);
+  sendResponse(res, 200, true, 'Logged out successfully', null);
 };

--- a/src/modules/auth/auth.routes.ts
+++ b/src/modules/auth/auth.routes.ts
@@ -3,7 +3,7 @@ import { asyncHandler } from '../../shared/http/asyncHandler.js';
 import { validate } from '../../shared/validation/validate.js';
 import { requireAuth } from '../../shared/middleware/requireAuth.js';
 import { SignupBodySchema, LoginBodySchema } from './auth.validation.js';
-import { signupController, loginController } from './auth.controller.js';
+import { signupController, loginController, logoutController } from './auth.controller.js';
 import {
   createApiKeyController,
   listApiKeysController,
@@ -14,6 +14,7 @@ export const authRouter = Router();
 
 authRouter.post('/signup', validate({ body: SignupBodySchema }), asyncHandler(signupController));
 authRouter.post('/login', validate({ body: LoginBodySchema }), asyncHandler(loginController));
+authRouter.post('/logout', asyncHandler(requireAuth), asyncHandler(logoutController));
 
 // API Key management routes (protected by JWT auth)
 authRouter.post('/api-keys', asyncHandler(requireAuth), asyncHandler(createApiKeyController));

--- a/src/modules/auth/auth.service.ts
+++ b/src/modules/auth/auth.service.ts
@@ -1,18 +1,24 @@
 import bcrypt from 'bcrypt';
 import jwt from 'jsonwebtoken';
+import { randomUUID } from 'crypto';
 import { AppError } from '../../shared/http/errors.js';
 import { env } from '../../env.js';
 import { UserModel, UserRole } from '../users/users.model.js';
+import { blockToken } from '../../infra/redis/tokenBlocklist.js';
 import type { SignupInput, LoginInput } from './auth.validation.js';
 
 export interface TokenPayload {
   userId: string;
   role: string;
   organizationId?: string;
+  jti: string;
 }
 
-function generateToken(payload: TokenPayload): string {
-  return jwt.sign(payload, env.JWT_SECRET, { expiresIn: '7d' });
+const TOKEN_TTL_SECONDS = 7 * 24 * 60 * 60; // 7 days
+
+function generateToken(payload: Omit<TokenPayload, 'jti'>): string {
+  const jti = randomUUID();
+  return jwt.sign({ ...payload, jti }, env.JWT_SECRET, { expiresIn: TOKEN_TTL_SECONDS });
 }
 
 export async function signup(input: SignupInput) {
@@ -78,4 +84,21 @@ export async function login(input: LoginInput) {
 
 export function verifyToken(token: string): TokenPayload {
   return jwt.verify(token, env.JWT_SECRET) as TokenPayload;
+}
+
+export async function logout(token: string): Promise<void> {
+  let payload: TokenPayload;
+  try {
+    payload = verifyToken(token);
+  } catch {
+    // Token already invalid — nothing to revoke
+    return;
+  }
+
+  const exp = (payload as TokenPayload & { exp?: number }).exp;
+  const ttl = exp ? exp - Math.floor(Date.now() / 1000) : TOKEN_TTL_SECONDS;
+
+  if (ttl > 0) {
+    await blockToken(payload.jti, ttl);
+  }
 }

--- a/src/shared/middleware/requireAuth.ts
+++ b/src/shared/middleware/requireAuth.ts
@@ -1,6 +1,7 @@
 import type { RequestHandler } from 'express';
 import { AppError } from '../http/errors.js';
 import { verifyToken, type TokenPayload } from '../../modules/auth/auth.service.js';
+import { isTokenBlocked } from '../../infra/redis/tokenBlocklist.js';
 
 declare global {
   namespace Express {
@@ -10,7 +11,7 @@ declare global {
   }
 }
 
-export const requireAuth: RequestHandler = (req, res, next) => {
+export const requireAuth: RequestHandler = async (req, res, next) => {
   const authHeader = req.headers.authorization;
 
   if (!authHeader || !authHeader.startsWith('Bearer ')) {
@@ -19,11 +20,17 @@ export const requireAuth: RequestHandler = (req, res, next) => {
 
   const token = authHeader.substring(7);
 
+  let payload: TokenPayload;
   try {
-    const payload = verifyToken(token);
-    req.user = payload;
-    next();
+    payload = verifyToken(token);
   } catch {
     throw new AppError(401, 'Invalid or expired token', 'UNAUTHORIZED');
   }
+
+  if (await isTokenBlocked(payload.jti)) {
+    throw new AppError(401, 'Token has been revoked', 'TOKEN_REVOKED');
+  }
+
+  req.user = payload;
+  next();
 };

--- a/tests/jwt-revocation.test.ts
+++ b/tests/jwt-revocation.test.ts
@@ -1,0 +1,31 @@
+import { isTokenBlocked, blockToken } from '../src/infra/redis/tokenBlocklist.js';
+import { getRedisClient } from '../src/infra/redis/connection.js';
+
+// Mock ioredis
+jest.mock('../src/infra/redis/connection.js', () => {
+  const store = new Map<string, string>();
+  const mockClient = {
+    set: jest.fn(async (key: string, value: string, _ex: string, ttl: number) => {
+      store.set(key, value);
+      // auto-expire simulation not needed for unit tests
+      return 'OK';
+    }),
+    exists: jest.fn(async (key: string) => (store.has(key) ? 1 : 0)),
+    _store: store,
+  };
+  return {
+    getRedisClient: () => mockClient,
+    redisConnection: mockClient,
+  };
+});
+
+describe('Token Blocklist', () => {
+  it('returns false for a token not in the blocklist', async () => {
+    expect(await isTokenBlocked('unknown-jti')).toBe(false);
+  });
+
+  it('returns true after blocking a token', async () => {
+    await blockToken('test-jti-123', 3600);
+    expect(await isTokenBlocked('test-jti-123')).toBe(true);
+  });
+});


### PR DESCRIPTION
closes #106
  
  PR Description:
  
  │ Adds a `POST /api/auth/logout` endpoint (protected by `requireAuth`). On logout, the token's `jti` (JWT ID) is written to Redis with a TTL matching
  the token's remaining lifetime. `requireAuth` now checks the blocklist before granting access — revoked tokens immediately return `401 TOKEN_REVOKED`.
  Includes `tokenBlocklist.ts` infra module and unit tests with a mocked Redis client.
  
 