### PR TITLE
feat: implement audit logging for critical state changes

### DIFF
--- a/src/modules/auth/apiKey.controller.ts
+++ b/src/modules/auth/apiKey.controller.ts
@@ -10,7 +10,7 @@ export const createApiKeyController: RequestHandler = async (req, res) => {
     throw new AppError(400, 'name and organizationId are required', 'VALIDATION_ERROR');
   }
 
-  const result = await generateApiKey({ name, organizationId, shipmentId });
+  const result = await generateApiKey({ name, organizationId, shipmentId, createdBy: req.user?.userId });
 
   sendResponse(
     res,

--- a/src/modules/auth/apiKey.service.ts
+++ b/src/modules/auth/apiKey.service.ts
@@ -3,11 +3,13 @@ import bcrypt from 'bcrypt';
 import { ApiKeyModel } from './apiKey.model.js';
 import type { IApiKey } from '../../shared/types/apiKey.js';
 import { AppError } from '../../shared/http/errors.js';
+import { auditLog } from '../../shared/utils/auditLog.js';
 
 interface CreateApiKeyParams {
   name: string;
   organizationId: string;
   shipmentId?: string;
+  createdBy?: string;
 }
 
 interface CreateApiKeyResult {
@@ -34,6 +36,16 @@ export async function generateApiKey(params: CreateApiKeyParams): Promise<Create
     shipmentId: params.shipmentId,
     isActive: true,
   });
+
+  if (params.createdBy) {
+    auditLog({
+      userId: params.createdBy,
+      action: 'API_KEY_GENERATED',
+      resourceId: apiKeyDoc._id.toString(),
+      timestamp: apiKeyDoc.createdAt,
+      metadata: { organizationId: params.organizationId, name: params.name },
+    });
+  }
 
   // Return the raw API key only once - it will never be shown again
   return {

--- a/src/modules/shipments/shipments.service.ts
+++ b/src/modules/shipments/shipments.service.ts
@@ -5,6 +5,7 @@ import { mockUploadToStorage } from '../../services/mockStorageService.js';
 import { UserModel } from '../users/users.model.js';
 import { emitStatusUpdate } from '../../infra/socket/io.js';
 import { IShipment, ShipmentStatus } from '../../shared/types/shipment.js';
+import { auditLog } from '../../shared/utils/auditLog.js';
 
 type ShipmentListResult = {
   data: IShipment[];
@@ -86,6 +87,7 @@ export const updateShipmentStatusService = async (
     throw new Error('Invalid status');
   }
 
+  const previousStatus = shipment.status;
   shipment.status = status;
 
   const milestone = {
@@ -129,6 +131,16 @@ export const updateShipmentStatusService = async (
   shipment.milestones.push(milestone);
 
   await shipment.save();
+
+  if (actor?.userId) {
+    auditLog({
+      userId: actor.userId,
+      action: 'SHIPMENT_STATUS_CHANGED',
+      resourceId: id,
+      timestamp: new Date(),
+      metadata: { previousStatus, newStatus: status },
+    });
+  }
 
   emitStatusUpdate(id, {
     shipmentId: id,

--- a/src/shared/utils/auditLog.ts
+++ b/src/shared/utils/auditLog.ts
@@ -1,0 +1,28 @@
+import { logger } from '../logger/logger.js';
+
+export type AuditAction =
+  | 'SHIPMENT_STATUS_CHANGED'
+  | 'RBAC_ROLE_MODIFIED'
+  | 'API_KEY_GENERATED';
+
+export interface AuditLogParams {
+  userId: string;
+  action: AuditAction;
+  resourceId: string;
+  timestamp: Date;
+  metadata?: Record<string, unknown>;
+}
+
+export function auditLog(params: AuditLogParams): void {
+  logger.info(
+    {
+      audit: true,
+      userId: params.userId,
+      action: params.action,
+      resourceId: params.resourceId,
+      timestamp: params.timestamp.toISOString(),
+      ...(params.metadata && { metadata: params.metadata }),
+    },
+    `AUDIT: ${params.action}`
+  );
+}


### PR DESCRIPTION
Add a lightweight audit logging utility (src/shared/utils/auditLog.ts) that emits a structured pino log entry with audit:true for any of:
  - SHIPMENT_STATUS_CHANGED
  - API_KEY_GENERATED
  - RBAC_ROLE_MODIFIED (type reserved for future role update endpoint)

Wire the utility into updateShipmentStatusService (recording the previous and new status) and generateApiKey (via new optional createdBy param threaded from createApiKeyController through req.user.userId).

Closes #111