### PR TITLE
feat: enforce authentication on GET /api/shipments endpoint

### DIFF
--- a/src/modules/shipments/shipments.routes.ts
+++ b/src/modules/shipments/shipments.routes.ts
@@ -26,6 +26,8 @@ const upload = multer({ storage: multer.memoryStorage() });
 
 shipmentsRouter.get(
   '/',
+  requireAuth,
+  requireRole('SUPER_ADMIN', 'ADMIN', 'MANAGER', 'VIEWER', 'CUSTOMER'),
   validateRequest({ query: ShipmentsQuerySchema }),
   asyncHandler(getShipments)
 );

--- a/tests/api-schema.snapshot.test.ts
+++ b/tests/api-schema.snapshot.test.ts
@@ -134,7 +134,9 @@ describe('API Schema Snapshot Tests', () => {
         milestones: [],
       });
 
-      const res = await request(app).get('/api/shipments?limit=10');
+      const res = await request(app)
+        .get('/api/shipments?limit=10')
+        .set('Authorization', `Bearer ${authToken}`);
 
       expect(res.status).toBe(200);
       expect(res.body).toMatchSnapshot();

--- a/tests/shipments.pagination.test.ts
+++ b/tests/shipments.pagination.test.ts
@@ -1,12 +1,18 @@
 import request from 'supertest';
+import jwt from 'jsonwebtoken';
 import { buildApp } from '../src/app.js';
 import { connectMongo } from '../src/infra/mongo/connection.js';
 import { Shipment } from '../src/modules/shipments/shipments.model.js';
 
 const app = buildApp();
+let authToken: string;
 
 beforeAll(async () => {
   await connectMongo(process.env.MONGO_URI!);
+  authToken = jwt.sign(
+    { userId: 'test-user-id', role: 'MANAGER' },
+    process.env.JWT_SECRET!
+  );
 });
 
 afterEach(async () => {
@@ -23,7 +29,9 @@ describe('GET /api/shipments - Cursor Pagination', () => {
       logisticsId: '507f1f77bcf86cd799439012',
     });
 
-    const res = await request(app).get('/api/shipments?limit=10');
+    const res = await request(app)
+      .get('/api/shipments?limit=10')
+      .set('Authorization', `Bearer ${authToken}`);
 
     expect(res.status).toBe(200);
     expect(res.body.data).toHaveLength(1);
@@ -42,13 +50,17 @@ describe('GET /api/shipments - Cursor Pagination', () => {
       });
     }
 
-    const firstPage = await request(app).get('/api/shipments?limit=2');
+    const firstPage = await request(app)
+      .get('/api/shipments?limit=2')
+      .set('Authorization', `Bearer ${authToken}`);
     expect(firstPage.status).toBe(200);
     expect(firstPage.body.data).toHaveLength(2);
     expect(firstPage.body.meta.hasMore).toBe(true);
     expect(firstPage.body.meta.nextCursor).toBeTruthy();
 
-    const secondPage = await request(app).get(`/api/shipments?limit=2&cursor=${firstPage.body.meta.nextCursor}`);
+    const secondPage = await request(app)
+      .get(`/api/shipments?limit=2&cursor=${firstPage.body.meta.nextCursor}`)
+      .set('Authorization', `Bearer ${authToken}`);
     expect(secondPage.status).toBe(200);
     expect(secondPage.body.data).toHaveLength(2);
 
@@ -77,7 +89,9 @@ describe('GET /api/shipments - Cursor Pagination', () => {
       status: 'IN_TRANSIT',
     });
 
-    const res = await request(app).get('/api/shipments?status=CREATED');
+    const res = await request(app)
+      .get('/api/shipments?status=CREATED')
+      .set('Authorization', `Bearer ${authToken}`);
     expect(res.status).toBe(200);
     expect(res.body.data).toHaveLength(1);
     expect(res.body.data[0].status).toBe('CREATED');

--- a/tests/shipments.test.ts
+++ b/tests/shipments.test.ts
@@ -1,5 +1,6 @@
 import { jest, describe, beforeAll, beforeEach, it, expect } from '@jest/globals';
 import request from 'supertest';
+import jwt from 'jsonwebtoken';
 import process from 'process';
 import type { Application } from 'express';
 
@@ -153,11 +154,16 @@ await jest.unstable_mockModule('../src/infra/socket/io.js', () => {
 describe('Shipments API (mocked DB)', () => {
   let app: Application;
   let buildApp: () => Application;
+  let authToken: string;
 
   beforeAll(async () => {
     const appModule = await import('../src/app.js');
     buildApp = appModule.buildApp as () => Application;
     app = buildApp();
+    authToken = jwt.sign(
+      { userId: 'test-user-id', role: 'MANAGER' },
+      process.env.JWT_SECRET!
+    );
   });
 
   beforeEach(async () => {
@@ -176,13 +182,17 @@ describe('Shipments API (mocked DB)', () => {
         status: 'CREATED',
       });
     }
-    const first = await request(app).get('/api/shipments?limit=5');
+    const first = await request(app)
+      .get('/api/shipments?limit=5')
+      .set('Authorization', `Bearer ${authToken}`);
     expect(first.status).toBe(200);
     expect(first.body.data).toHaveLength(5);
     expect(first.body.meta.hasMore).toBe(true);
     expect(first.body.meta.nextCursor).toBeTruthy();
 
-    const second = await request(app).get(`/api/shipments?limit=5&cursor=${first.body.meta.nextCursor}`);
+    const second = await request(app)
+      .get(`/api/shipments?limit=5&cursor=${first.body.meta.nextCursor}`)
+      .set('Authorization', `Bearer ${authToken}`);
     expect(second.status).toBe(200);
     expect(second.body.data).toHaveLength(5);
     const firstIds = first.body.data.map((s: { _id: string }) => s._id);
@@ -194,7 +204,9 @@ describe('Shipments API (mocked DB)', () => {
     const mod = await import('../src/modules/shipments/shipments.model.js');
     await mod.Shipment.create({ trackingNumber: 'TN1', origin: 'A', destination: 'B', enterpriseId: 'ent1', logisticsId: 'log1', status: 'IN_TRANSIT' });
     await mod.Shipment.create({ trackingNumber: 'TN2', origin: 'A', destination: 'B', enterpriseId: 'ent2', logisticsId: 'log2', status: 'DELIVERED' });
-    const res = await request(app).get('/api/shipments?status=IN_TRANSIT&limit=20');
+    const res = await request(app)
+      .get('/api/shipments?status=IN_TRANSIT&limit=20')
+      .set('Authorization', `Bearer ${authToken}`);
     expect(res.status).toBe(200);
     expect(res.body.data.length).toBe(1);
     expect(res.body.data[0].status).toBe('IN_TRANSIT');


### PR DESCRIPTION
GET / lacked requireAuth and requireRole, allowing anyone to list all shipments without credentials. Add both middlewares with the full role set (SUPER_ADMIN, ADMIN, MANAGER, VIEWER, CUSTOMER) — matching the existing RBAC matrix — so unauthenticated requests return 401 and requests from unlisted roles return 403.

Update three test files that called GET /api/shipments without a token (shipments.test.ts, shipments.pagination.test.ts,
api-schema.snapshot.test.ts) to include a signed JWT so they continue to pass.

Closes #109