### PR TITLE
feat: implement graceful server shutdown on SIGTERM and SIGINT

### DIFF
--- a/src/infra/redis/connection.ts
+++ b/src/infra/redis/connection.ts
@@ -15,3 +15,10 @@ export function getRedisClient(): RedisClient {
 }
 
 export const redisConnection = getRedisClient();
+
+export async function disconnectRedis(): Promise<void> {
+  if (redisClient) {
+    await (redisClient as import('ioredis').Redis).quit();
+    redisClient = null;
+  }
+}

--- a/src/infra/socket/io.ts
+++ b/src/infra/socket/io.ts
@@ -78,6 +78,17 @@ export function getIO(): Server {
   return io;
 }
 
+export function closeSocketIO(): Promise<void> {
+  return new Promise(resolve => {
+    if (io) {
+      io.close(() => resolve());
+      io = null;
+    } else {
+      resolve();
+    }
+  });
+}
+
 export function emitAnomalyDetected(shipmentId: string, anomaly: AnomalyAlertPayload) {
   getIO().to(shipmentRoomName(shipmentId)).emit('anomaly_detected', anomaly);
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -3,8 +3,9 @@ import './loadEnv.js';
 import { createServer } from 'http';
 import { buildApp } from './app.js';
 import { config } from './config/index.js';
-import { connectMongo } from './infra/mongo/connection.js';
-import { initSocketIO } from './infra/socket/io.js';
+import { connectMongo, disconnectMongo } from './infra/mongo/connection.js';
+import { disconnectRedis } from './infra/redis/connection.js';
+import { initSocketIO, closeSocketIO } from './infra/socket/io.js';
 import { startAlertWorker } from './workers/alert.worker.js';
 import { logger } from './shared/logger/logger.js';
 
@@ -14,11 +15,38 @@ async function main() {
   const app = buildApp();
   const httpServer = createServer(app);
   initSocketIO(httpServer);
-  startAlertWorker();
+  const worker = startAlertWorker();
 
   httpServer.listen(config.port, () => {
     logger.info({ port: config.port }, 'HTTP server listening');
   });
+
+  function shutdown(signal: string) {
+    logger.info({ signal }, 'Shutdown signal received');
+
+    const forceExit = setTimeout(() => {
+      logger.error('Graceful shutdown timed out, forcing exit');
+      process.exit(1);
+    }, 30_000);
+    forceExit.unref();
+
+    httpServer.close(async () => {
+      try {
+        await worker.close();
+        await closeSocketIO();
+        await disconnectRedis();
+        await disconnectMongo();
+        logger.info('Graceful shutdown complete');
+        process.exit(0);
+      } catch (err) {
+        logger.error({ err }, 'Error during shutdown');
+        process.exit(1);
+      }
+    });
+  }
+
+  process.once('SIGTERM', () => shutdown('SIGTERM'));
+  process.once('SIGINT', () => shutdown('SIGINT'));
 }
 
 main().catch(err => {


### PR DESCRIPTION
- Add disconnectRedis() to infra/redis/connection.ts to cleanly quit the ioredis client
- Add closeSocketIO() to infra/socket/io.ts to gracefully close the Socket.io server
- Register process.once handlers for SIGTERM and SIGINT in main.ts
- Shutdown sequence: HTTP server drain → BullMQ worker → Socket.io → Redis → MongoDB
- 30-second force-exit timer with .unref() to avoid blocking natural exit

Closes #102