### PR TITLE
feat: containerize app with multi-stage Dockerfile

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,7 @@
+node_modules
+dist
+.env
+.env.*
+.git
+coverage
+*.log

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,19 +1,33 @@
-FROM node:20-alpine
+# ── Stage 1: production dependencies only ─────────────────────────────────────
+FROM node:20-alpine AS deps
+WORKDIR /app
+COPY package*.json ./
+RUN npm ci --omit=dev
 
+# ── Stage 2: build (TypeScript compilation) ───────────────────────────────────
+FROM node:20-alpine AS builder
+WORKDIR /app
+COPY package*.json ./
+RUN npm ci
+COPY . .
+RUN npm run build
+
+# ── Stage 3: production runner ────────────────────────────────────────────────
+FROM node:20-alpine AS runner
 WORKDIR /app
 
-# Install dependencies
-COPY package*.json ./
-RUN npm install
+COPY --from=deps    /app/node_modules ./node_modules
+COPY --from=builder /app/dist         ./dist
 
-# Copy source code
-COPY . .
+# swagger.yaml is resolved at runtime as dist/docs/swagger.yaml
+# (src/app.ts uses new URL('../docs/swagger.yaml', import.meta.url) from dist/src/app.js)
+COPY docs ./dist/docs
 
-# Expose the API port
+COPY package.json ./
+
 EXPOSE 3000
 
-# Native Docker healthcheck querying the health endpoint
 HEALTHCHECK --interval=30s --timeout=10s --start-period=10s --retries=3 \
   CMD wget --no-verbose --tries=1 --spider http://localhost:3000/api/health || exit 1
 
-CMD ["npm", "start"]
+CMD ["node", "dist/src/main.js"]

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "dev": "tsx watch src/main.ts",
     "build": "tsc -p tsconfig.json",
-    "start": "node dist/main.js",
+    "start": "node dist/src/main.js",
     "typecheck": "tsc -p tsconfig.json --noEmit",
     "lint": "eslint src --ext .ts",
     "lint:fix": "eslint src --ext .ts --fix",


### PR DESCRIPTION
- Rewrite Dockerfile using three named stages: deps (prod-only npm ci), builder (full install + tsc compilation), runner (lightweight Alpine image)
- Add .dockerignore to exclude node_modules, dist, .env*, and build artifacts
- Fix npm start script: node dist/main.js → node dist/src/main.js (tsconfig rootDir:"." outputs src/main.ts to dist/src/main.js)
- Final image contains only compiled dist/ and production node_modules; no TypeScript compiler or dev dependencies in the runner stage

Closes #97