### PR TITLE
feat: integrate migrate-mongo for tracked schema migrations

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -50,6 +50,6 @@ export default [
     },
   },
   {
-    ignores: ['dist', 'node_modules', 'coverage'],
+    ignores: ['dist', 'node_modules', 'coverage', 'migrations'],
   },
 ];

--- a/migrate-mongo.config.cjs
+++ b/migrate-mongo.config.cjs
@@ -1,0 +1,16 @@
+'use strict';
+
+const config = {
+  mongodb: {
+    url: process.env.MONGO_URI,
+    options: {
+      serverSelectionTimeoutMS: 5000,
+    },
+  },
+  migrationsDir: 'migrations',
+  changelogCollectionName: 'changelog',
+  migrationFileExtension: '.js',
+  useFileHash: false,
+};
+
+module.exports = config;

--- a/migrations/20240101000000-add-compound-indexes.js
+++ b/migrations/20240101000000-add-compound-indexes.js
@@ -1,0 +1,49 @@
+'use strict';
+
+module.exports = {
+  async up(db) {
+    const shipments = db.collection('shipments');
+    await shipments.createIndex({ status: 1, createdAt: -1 });
+    await shipments.createIndex({ enterpriseId: 1, createdAt: -1 });
+    await shipments.createIndex({ logisticsId: 1, createdAt: -1 });
+    await shipments.createIndex({ createdAt: -1, _id: -1 });
+
+    const anomalies = db.collection('anomalies');
+    await anomalies.createIndex({ shipmentId: 1, timestamp: -1, _id: -1 });
+    await anomalies.createIndex({ resolved: 1, timestamp: -1, _id: -1 });
+    await anomalies.createIndex({ severity: 1, timestamp: -1, _id: -1 });
+    await anomalies.createIndex({ severity: 1, shipmentId: 1, timestamp: -1, _id: -1 });
+
+    const telemetries = db.collection('telemetries');
+    await telemetries.createIndex({ shipmentId: 1, timestamp: -1 });
+    await telemetries.createIndex({ anchorStatus: 1 });
+
+    const apikeys = db.collection('apikeys');
+    await apikeys.createIndex({ keyHash: 1 });
+    await apikeys.createIndex({ organizationId: 1 });
+    await apikeys.createIndex({ shipmentId: 1 });
+  },
+
+  async down(db) {
+    const shipments = db.collection('shipments');
+    await shipments.dropIndex({ status: 1, createdAt: -1 });
+    await shipments.dropIndex({ enterpriseId: 1, createdAt: -1 });
+    await shipments.dropIndex({ logisticsId: 1, createdAt: -1 });
+    await shipments.dropIndex({ createdAt: -1, _id: -1 });
+
+    const anomalies = db.collection('anomalies');
+    await anomalies.dropIndex({ shipmentId: 1, timestamp: -1, _id: -1 });
+    await anomalies.dropIndex({ resolved: 1, timestamp: -1, _id: -1 });
+    await anomalies.dropIndex({ severity: 1, timestamp: -1, _id: -1 });
+    await anomalies.dropIndex({ severity: 1, shipmentId: 1, timestamp: -1, _id: -1 });
+
+    const telemetries = db.collection('telemetries');
+    await telemetries.dropIndex({ shipmentId: 1, timestamp: -1 });
+    await telemetries.dropIndex({ anchorStatus: 1 });
+
+    const apikeys = db.collection('apikeys');
+    await apikeys.dropIndex({ keyHash: 1 });
+    await apikeys.dropIndex({ organizationId: 1 });
+    await apikeys.dropIndex({ shipmentId: 1 });
+  },
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,7 @@
         "express-rate-limit": "^8.1.0",
         "ioredis": "^5.10.1",
         "jsonwebtoken": "^9.0.3",
+        "migrate-mongo": "^11.0.0",
         "mongoose": "^8.9.5",
         "multer": "^2.0.2",
         "pino": "^9.14.0",
@@ -520,6 +521,15 @@
         "@babel/core": "^7.0.0-0"
       }
     },
+    "node_modules/@babel/runtime": {
+      "version": "7.29.2",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.2.tgz",
+      "integrity": "sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
     "node_modules/@babel/template": {
       "version": "7.28.6",
       "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.28.6.tgz",
@@ -599,6 +609,16 @@
       "integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@colors/colors": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@colors/colors/-/colors-1.5.0.tgz",
+      "integrity": "sha512-ooWCrlZP11i8GImSjTHYHLkvFDP48nS4+204nGb1RiX/WXYHmJA2III9/e2DWVabCESdW7hBAEzHRqUn9OUVvQ==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=0.1.90"
+      }
     },
     "node_modules/@emnapi/core": {
       "version": "1.8.1",
@@ -3952,6 +3972,62 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/cli-table3": {
+      "version": "0.6.5",
+      "resolved": "https://registry.npmjs.org/cli-table3/-/cli-table3-0.6.5.tgz",
+      "integrity": "sha512-+W/5efTR7y5HRD7gACw9yQjqMVvEMLBHmboM/kPWam+H+Hmyrgjh6YncVKK122YZkXrLudzTuAukUw9FnMf7IQ==",
+      "license": "MIT",
+      "dependencies": {
+        "string-width": "^4.2.0"
+      },
+      "engines": {
+        "node": "10.* || >= 12.*"
+      },
+      "optionalDependencies": {
+        "@colors/colors": "1.5.0"
+      }
+    },
+    "node_modules/cli-table3/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/cli-table3/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "license": "MIT"
+    },
+    "node_modules/cli-table3/node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/cli-table3/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/cli-truncate": {
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/cli-truncate/-/cli-truncate-5.2.0.tgz",
@@ -4269,6 +4345,22 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/date-fns": {
+      "version": "2.30.0",
+      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-2.30.0.tgz",
+      "integrity": "sha512-fnULvOpxnC5/Vg3NCiWelDsLiUc9bRwAPs/+LfTLNvetFCtCTN+yQz15C/fs4AwX1R9K5GLtLfn8QW+dWisaAw==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.21.0"
+      },
+      "engines": {
+        "node": ">=0.11"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/date-fns"
       }
     },
     "node_modules/dateformat": {
@@ -5273,6 +5365,15 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/fn-args": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/fn-args/-/fn-args-5.0.0.tgz",
+      "integrity": "sha512-CtbfI3oFFc3nbdIoHycrfbrxiGgxXBXXuyOl49h47JawM1mYrqpiRqnH5CB2mBatdXvHHOUO6a+RiAuuvKt0lw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/follow-redirects": {
       "version": "1.15.11",
       "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.11.tgz",
@@ -5375,6 +5476,20 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/fs-extra": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.1.0.tgz",
+      "integrity": "sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==",
+      "license": "MIT",
+      "dependencies": {
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^6.0.1",
+        "universalify": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/fs.realpath": {
@@ -5597,7 +5712,6 @@
       "version": "4.2.11",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
       "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/handlebars": {
@@ -5969,7 +6083,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
       "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -6877,6 +6990,18 @@
         "node": ">=6"
       }
     },
+    "node_modules/jsonfile": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.2.1.tgz",
+      "integrity": "sha512-zwOTdL3rFQ/lRdBnntKVOX6k5cKJwEc1HdilT71BWEu7J41gXIB2MRp+vxduPSwZJPWBxEzv4yH1wYLJGUHX4Q==",
+      "license": "MIT",
+      "dependencies": {
+        "universalify": "^2.0.0"
+      },
+      "optionalDependencies": {
+        "graceful-fs": "^4.1.6"
+      }
+    },
     "node_modules/jsonwebtoken": {
       "version": "9.0.3",
       "resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-9.0.3.tgz",
@@ -7114,6 +7239,12 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/lodash": {
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
+      "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
+      "license": "MIT"
     },
     "node_modules/lodash.defaults": {
       "version": "4.2.0",
@@ -7427,6 +7558,39 @@
       },
       "engines": {
         "node": ">=8.6"
+      }
+    },
+    "node_modules/migrate-mongo": {
+      "version": "11.0.0",
+      "resolved": "https://registry.npmjs.org/migrate-mongo/-/migrate-mongo-11.0.0.tgz",
+      "integrity": "sha512-GB/gHzUwp/fL1w6ksNGihTyb+cSrm6NbVLlz1OSkQKaLlzAXMwH7iKK2ZS7W5v+I8vXiY2rL58WTUZSAL6QR+A==",
+      "license": "MIT",
+      "dependencies": {
+        "cli-table3": "^0.6.1",
+        "commander": "^9.1.0",
+        "date-fns": "^2.28.0",
+        "fn-args": "^5.0.0",
+        "fs-extra": "^10.0.1",
+        "lodash": "^4.17.21",
+        "p-each-series": "^2.2.0"
+      },
+      "bin": {
+        "migrate-mongo": "bin/migrate-mongo.js"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "peerDependencies": {
+        "mongodb": "^4.4.1 || ^5.0.0 || ^6.0.0"
+      }
+    },
+    "node_modules/migrate-mongo/node_modules/commander": {
+      "version": "9.5.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-9.5.0.tgz",
+      "integrity": "sha512-KRs7WVDKg86PWiuAqhDrAQnTXZKraVcCc6vFdL14qrZ/DcWwuRo7VoiYXalXO7S5GKpqYiVEwCbgFDfxNHKJBQ==",
+      "license": "MIT",
+      "engines": {
+        "node": "^12.20.0 || >=14"
       }
     },
     "node_modules/mime": {
@@ -8033,6 +8197,18 @@
       },
       "engines": {
         "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/p-each-series": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/p-each-series/-/p-each-series-2.2.0.tgz",
+      "integrity": "sha512-ycIL2+1V32th+8scbpTvyHNaHe02z0sjgh91XXjAk+ZeXoPN4Z46DVUnzdso0aX4KckKw0FNNFHdjZ2UsZvxiA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/p-limit": {
@@ -10019,6 +10195,15 @@
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
       "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
       "license": "MIT"
+    },
+    "node_modules/universalify": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
+      "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10.0.0"
+      }
     },
     "node_modules/unpipe": {
       "version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -14,10 +14,14 @@
     "seed": "tsx src/scripts/seed.ts",
     "generate-api-key": "tsx src/scripts/generateApiKey.ts",
     "worker:stellar": "tsx src/workers/stellar.worker.ts",
+    "migrate:up": "migrate-mongo up --config migrate-mongo.config.cjs",
+    "migrate:down": "migrate-mongo down --config migrate-mongo.config.cjs",
+    "migrate:status": "migrate-mongo status --config migrate-mongo.config.cjs",
     "prepare": "husky"
   },
   "dependencies": {
     "@faker-js/faker": "^10.3.0",
+    "migrate-mongo": "^11.0.0",
     "@stellar/stellar-sdk": "^14.5.0",
     "@types/ioredis": "^4.28.10",
     "bcrypt": "^6.0.0",


### PR DESCRIPTION
- Install migrate-mongo as a production dependency
- Add migrate-mongo.config.cjs (CJS extension required for ESM projects); reads MONGO_URI from env, targets the migrations/ directory
- Create initial migration 20240101000000-add-compound-indexes.js with up/down functions covering all compound indexes from: shipments (4), anomalies (4), telemetry (2), apikeys (3)
- Add migrate:up, migrate:down, migrate:status npm scripts
- Exclude migrations/ from ESLint: migration files are CommonJS scripts and are not application source code

Closes #100