### PR TITLE
[142] [Optimization] Configure Helmet security headers for Dev Weak ETags

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -1,10 +1,7 @@
 import './loadEnv.js';
 import express from 'express';
-import cors from 'cors';
-import helmet from 'helmet';
 import morgan from 'morgan';
 import { fileURLToPath } from 'node:url';
-import helmet from 'helmet';
 import swaggerUi from 'swagger-ui-express';
 import YAML from 'yamljs';
 
@@ -13,6 +10,7 @@ import { notFound } from './shared/middleware/notFound.js';
 import { errorMiddleware } from './shared/http/errorMiddleware.js';
 import { standardLimiter, loginLimiter } from './shared/middleware/rateLimiter.js';
 import { corsMiddleware, corsPreflight } from './config/cors.js';
+import { buildHelmetMiddleware } from './config/helmet.js';
 
 import { healthRouter } from './modules/health/health.routes.js';
 import { usersRouter } from './modules/users/users.routes.js';
@@ -28,11 +26,10 @@ const swaggerDocumentPath = fileURLToPath(new URL('../docs/swagger.yaml', import
 export function buildApp() {
   const app = express();
 
-  app.use(helmet());
+  app.use(buildHelmetMiddleware());
   // Enable weak ETags globally for client-side caching (Issue #80)
   app.set('etag', 'weak');
 
-  app.use(helmet());
   app.use(requestId());
   app.use(corsMiddleware);
   app.options('*', corsPreflight);

--- a/src/config/__tests__/helmet.test.ts
+++ b/src/config/__tests__/helmet.test.ts
@@ -1,0 +1,50 @@
+import { describe, it, expect, beforeEach, afterEach } from '@jest/globals';
+import request from 'supertest';
+import express from 'express';
+import { buildHelmetMiddleware } from '../helmet.js';
+
+describe('Helmet configuration', () => {
+  const previousNodeEnv = process.env.NODE_ENV;
+
+  afterEach(() => {
+    process.env.NODE_ENV = previousNodeEnv;
+  });
+
+  it('applies relaxed CSP directives in development', async () => {
+    process.env.NODE_ENV = 'development';
+    const app = express();
+    app.use(buildHelmetMiddleware());
+    app.get('/health', (_req, res) => res.status(200).send('ok'));
+
+    const res = await request(app).get('/health');
+    expect(res.status).toBe(200);
+    expect(res.headers['content-security-policy']).toContain("'unsafe-inline'");
+  });
+
+  it('applies strict CSP directives in production', async () => {
+    process.env.NODE_ENV = 'production';
+    const app = express();
+    app.use(buildHelmetMiddleware());
+    app.get('/health', (_req, res) => res.status(200).send('ok'));
+
+    const res = await request(app).get('/health');
+    expect(res.status).toBe(200);
+    expect(res.headers['content-security-policy']).toContain("default-src 'self'");
+    expect(res.headers['content-security-policy']).not.toContain("'unsafe-eval'");
+  });
+
+  it('does not strip weak ETag support from downstream handlers', async () => {
+    process.env.NODE_ENV = 'development';
+    const app = express();
+    app.use(buildHelmetMiddleware());
+    app.set('etag', 'weak');
+    app.get('/health', (_req, res) => res.status(200).send('ok'));
+
+    const first = await request(app).get('/health');
+    const etag = first.headers.etag;
+    expect(etag).toBeDefined();
+
+    const second = await request(app).get('/health').set('If-None-Match', etag as string);
+    expect(second.status).toBe(304);
+  });
+});

--- a/src/config/helmet.ts
+++ b/src/config/helmet.ts
@@ -1,0 +1,38 @@
+import helmet from 'helmet';
+
+export function buildHelmetMiddleware() {
+  const isProduction = process.env.NODE_ENV === 'production';
+
+  if (isProduction) {
+    return helmet({
+      contentSecurityPolicy: {
+        directives: {
+          defaultSrc: ["'self'"],
+          scriptSrc: ["'self'"],
+          styleSrc: ["'self'"],
+          imgSrc: ["'self'", 'data:', 'https:'],
+          connectSrc: ["'self'"],
+          fontSrc: ["'self'", 'https:', 'data:'],
+          objectSrc: ["'none'"],
+          frameAncestors: ["'none'"],
+        },
+      },
+    });
+  }
+
+  return helmet({
+    contentSecurityPolicy: {
+      directives: {
+        defaultSrc: ["'self'"],
+        scriptSrc: ["'self'", "'unsafe-inline'", "'unsafe-eval'"],
+        styleSrc: ["'self'", "'unsafe-inline'"],
+        imgSrc: ["'self'", 'data:', 'https:'],
+        connectSrc: ["'self'", 'ws:', 'wss:'],
+        fontSrc: ["'self'", 'https:', 'data:'],
+        objectSrc: ["'none'"],
+        frameAncestors: ["'self'"],
+      },
+    },
+    crossOriginEmbedderPolicy: false,
+  });
+}


### PR DESCRIPTION
## Summary
- Adds `buildHelmetMiddleware()` with customized CSP directives for development and production
- Relaxes dev CSP (`unsafe-inline`, websocket connects) so local tooling and inline assets work without blocking weak ETags
- Keeps production CSP strict while preserving Express weak ETag behavior

## Test plan
- [x] `npm run build` passes
- [x] Helmet unit tests verify dev vs prod CSP headers and 304 weak ETag responses
- [x] Existing ETag integration tests pass

Closes #142