### PR TITLE
[#173] [Feature] Build Team Members list REST endpoint GET /api/users

### DIFF
--- a/src/modules/users/users.controller.ts
+++ b/src/modules/users/users.controller.ts
@@ -11,3 +11,12 @@ export const deleteUserController: RequestHandler = async (req, res) => {
   await usersService.deleteUser(req.params.id);
   res.json({ success: true, message: 'User deleted successfully' });
 };
+
+export const listUsersController: RequestHandler = async (req, res) => {
+  const users = await usersService.listOrganizationUsers({
+    organizationId: req.user?.organizationId,
+    role: req.user?.role,
+  });
+
+  sendResponse(res, 200, true, 'Users retrieved successfully', users);
+};

--- a/src/modules/users/users.repo.ts
+++ b/src/modules/users/users.repo.ts
@@ -7,3 +7,7 @@ export async function createUser(input: { email: string; name: string }) {
 export async function findUserByEmail(email: string) {
   return UserModel.findOne({ email }).lean();
 }
+
+export async function findUsersByOrganizationId(organizationId: string) {
+  return UserModel.find({ organizationId }).select('-passwordHash').lean();
+}

--- a/src/modules/users/users.routes.ts
+++ b/src/modules/users/users.routes.ts
@@ -3,7 +3,7 @@ import { asyncHandler } from '../../shared/http/asyncHandler.js';
 import { validateRequest } from '../../shared/validation/validate.js';
 import { z } from 'zod';
 import { CreateUserBodySchema } from './users.validation.js';
-import { createUserController, deleteUserController } from './users.controller.js';
+import { createUserController, deleteUserController, listUsersController } from './users.controller.js';
 import { requireAuth } from '../../shared/middleware/requireAuth.js';
 import { requireRole } from '../../shared/middleware/requireRole.js';
 
@@ -15,6 +15,12 @@ usersRouter.post(
   '/',
   validateRequest({ body: CreateUserBodySchema }),
   asyncHandler(createUserController)
+);
+usersRouter.get(
+  '/',
+  requireAuth,
+  requireRole(UserRole.ADMIN, UserRole.MANAGER, UserRole.SUPER_ADMIN),
+  asyncHandler(listUsersController)
 );
 usersRouter.delete(
   '/:id',

--- a/src/modules/users/users.service.ts
+++ b/src/modules/users/users.service.ts
@@ -1,11 +1,29 @@
 import { AppError } from '../../shared/http/errors.js';
-import { createUser, findUserByEmail } from './users.repo.js';
+import { createUser, findUserByEmail, findUsersByOrganizationId } from './users.repo.js';
 import { UserModel } from './users.model.js';
+import { UserRole } from '../../shared/constants/index.js';
 
 export async function registerUser(input: { email: string; name: string }) {
   const existing = await findUserByEmail(input.email);
   if (existing) throw new AppError(409, 'Email already in use', 'EMAIL_TAKEN');
   return createUser(input);
+}
+
+export async function listOrganizationUsers(input: {
+  organizationId?: string;
+  role?: string;
+}) {
+  const allowedRoles = [UserRole.SUPER_ADMIN, UserRole.ADMIN, UserRole.MANAGER];
+
+  if (!input.role || !allowedRoles.includes(input.role as UserRole)) {
+    throw new AppError(403, 'Forbidden: insufficient role', 'FORBIDDEN');
+  }
+
+  if (!input.organizationId) {
+    throw new AppError(403, 'Organization context is required', 'FORBIDDEN');
+  }
+
+  return findUsersByOrganizationId(input.organizationId);
 }
 
 export async function deleteUser(id: string) {

--- a/tests/users.list.controller.test.ts
+++ b/tests/users.list.controller.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, beforeEach, it, jest } from '@jest/globals';
+import request from 'supertest';
+import jwt from 'jsonwebtoken';
+import type { Application } from 'express';
+
+describe('GET /api/users', () => {
+  let app: Application;
+  const findUsersByOrganizationId = jest.fn();
+
+  beforeEach(async () => {
+    jest.resetModules();
+    jest.clearAllMocks();
+
+    findUsersByOrganizationId.mockImplementation(async (organizationId: string) => {
+      if (organizationId === 'org-a') {
+        return [
+          { _id: 'u1', email: 'admin@orga.com', organizationId: 'org-a', role: 'ADMIN' },
+          { _id: 'u2', email: 'manager@orga.com', organizationId: 'org-a', role: 'MANAGER' },
+        ];
+      }
+      return [];
+    });
+
+    await jest.unstable_mockModule('../src/modules/users/users.repo.js', () => ({
+      createUser: jest.fn(),
+      findUserByEmail: jest.fn(),
+      findUsersByOrganizationId,
+    }));
+
+    const appModule = await import('../src/app.js');
+    app = appModule.buildApp();
+  });
+
+  it('returns users for the authenticated organization', async () => {
+    const token = jwt.sign(
+      { userId: 'actor-1', role: 'ADMIN', organizationId: 'org-a' },
+      process.env.JWT_SECRET!,
+    );
+
+    const res = await request(app).get('/api/users').set('Authorization', `Bearer ${token}`);
+
+    expect(res.status).toBe(200);
+    expect(res.body.success).toBe(true);
+    expect(Array.isArray(res.body.data)).toBe(true);
+    expect(res.body.data).toHaveLength(2);
+    expect(findUsersByOrganizationId).toHaveBeenCalledWith('org-a');
+  });
+
+  it('returns 403 for unauthorized roles', async () => {
+    const token = jwt.sign(
+      { userId: 'viewer-1', role: 'VIEWER', organizationId: 'org-a' },
+      process.env.JWT_SECRET!,
+    );
+
+    const res = await request(app).get('/api/users').set('Authorization', `Bearer ${token}`);
+
+    expect(res.status).toBe(403);
+    expect(String(res.body.message)).toMatch(/forbidden/i);
+  });
+
+  it('returns 403 when organization context is missing', async () => {
+    const token = jwt.sign({ userId: 'admin-1', role: 'ADMIN' }, process.env.JWT_SECRET!);
+
+    const res = await request(app).get('/api/users').set('Authorization', `Bearer ${token}`);
+
+    expect(res.status).toBe(403);
+    expect(String(res.body.message)).toMatch(/organization context/i);
+  });
+});

--- a/tests/users.service.repo.test.ts
+++ b/tests/users.service.repo.test.ts
@@ -13,10 +13,12 @@ describe('users service and repo', () => {
       ...input,
     }));
     const findUserByEmail = jest.fn(async () => null);
+    const findUsersByOrganizationId = jest.fn(async () => []);
 
     await jest.unstable_mockModule('../src/modules/users/users.repo.js', () => ({
       createUser,
       findUserByEmail,
+      findUsersByOrganizationId,
     }));
 
     const { registerUser } = await import('../src/modules/users/users.service.js');
@@ -30,10 +32,12 @@ describe('users service and repo', () => {
   it('registerUser throws when email is already in use', async () => {
     const createUser = jest.fn();
     const findUserByEmail = jest.fn(async () => ({ _id: 'u1', email: 'existing@example.com' }));
+    const findUsersByOrganizationId = jest.fn(async () => []);
 
     await jest.unstable_mockModule('../src/modules/users/users.repo.js', () => ({
       createUser,
       findUserByEmail,
+      findUsersByOrganizationId,
     }));
 
     const { registerUser } = await import('../src/modules/users/users.service.js');


### PR DESCRIPTION
Closes #173

## Summary
- add GET /api/users endpoint with auth and role checks
- enforce organization-scoped listing based on JWT organizationId
- add controller/service/repo coverage for organization isolation and forbidden paths

## Validation
- npm run build
- npm test