### PR TITLE
[#174] [Feature] Token-based User Invitation links generation

### DIFF
--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -209,6 +209,75 @@ paths:
           description: Unauthorized
         '404':
           description: API key not found
+  /api/users/invitations:
+    post:
+      summary: Generate user invitation link
+      description: Creates a signed 48-hour invitation token bound to the inviter organization and target role.
+      security:
+        - bearerAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required:
+                - email
+                - role
+              properties:
+                email:
+                  type: string
+                  format: email
+                role:
+                  type: string
+                  enum: [ADMIN, MANAGER, VIEWER, CUSTOMER]
+      responses:
+        '201':
+          description: Invitation generated
+        '403':
+          description: Forbidden
+  /api/users/invitations/verify:
+    get:
+      summary: Verify invitation token
+      parameters:
+        - in: query
+          name: token
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Invitation token is valid
+        '401':
+          description: Invalid or expired invitation token
+  /api/users/invitations/accept:
+    post:
+      summary: Accept invitation and create account
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required:
+                - token
+                - name
+                - password
+              properties:
+                token:
+                  type: string
+                name:
+                  type: string
+                password:
+                  type: string
+                  minLength: 6
+      responses:
+        '201':
+          description: Invitation accepted
+        '401':
+          description: Invalid or expired invitation token
+        '409':
+          description: Email already in use
   /api/analytics/performance:
     get:
       summary: Get analytics performance dashboard

--- a/src/modules/users/users.controller.ts
+++ b/src/modules/users/users.controller.ts
@@ -11,3 +11,30 @@ export const deleteUserController: RequestHandler = async (req, res) => {
   await usersService.deleteUser(req.params.id);
   res.json({ success: true, message: 'User deleted successfully' });
 };
+
+export const createInvitationController: RequestHandler = async (req, res) => {
+  const invitation = await usersService.generateInvitationLink({
+    email: req.body.email,
+    role: req.body.role,
+    inviterUserId: req.user?.userId ?? '',
+    inviterRole: req.user?.role,
+    organizationId: req.user?.organizationId,
+  });
+
+  sendResponse(res, 201, true, 'Invitation link generated successfully', invitation);
+};
+
+export const verifyInvitationController: RequestHandler = async (req, res) => {
+  const invite = usersService.verifyInvitationToken(String(req.query.token));
+  sendResponse(res, 200, true, 'Invitation token verified successfully', invite);
+};
+
+export const acceptInvitationController: RequestHandler = async (req, res) => {
+  const user = await usersService.acceptInvitation({
+    token: req.body.token,
+    name: req.body.name,
+    password: req.body.password,
+  });
+
+  sendResponse(res, 201, true, 'Invitation accepted successfully', user);
+};

--- a/src/modules/users/users.routes.ts
+++ b/src/modules/users/users.routes.ts
@@ -2,8 +2,19 @@ import { Router } from 'express';
 import { asyncHandler } from '../../shared/http/asyncHandler.js';
 import { validateRequest } from '../../shared/validation/validate.js';
 import { z } from 'zod';
-import { CreateUserBodySchema } from './users.validation.js';
-import { createUserController, deleteUserController } from './users.controller.js';
+import {
+  AcceptInvitationBodySchema,
+  CreateInvitationBodySchema,
+  CreateUserBodySchema,
+  VerifyInvitationQuerySchema,
+} from './users.validation.js';
+import {
+  acceptInvitationController,
+  createInvitationController,
+  createUserController,
+  deleteUserController,
+  verifyInvitationController,
+} from './users.controller.js';
 import { requireAuth } from '../../shared/middleware/requireAuth.js';
 import { requireRole } from '../../shared/middleware/requireRole.js';
 
@@ -15,6 +26,23 @@ usersRouter.post(
   '/',
   validateRequest({ body: CreateUserBodySchema }),
   asyncHandler(createUserController)
+);
+usersRouter.post(
+  '/invitations',
+  requireAuth,
+  requireRole(UserRole.ADMIN, UserRole.SUPER_ADMIN),
+  validateRequest({ body: CreateInvitationBodySchema }),
+  asyncHandler(createInvitationController)
+);
+usersRouter.get(
+  '/invitations/verify',
+  validateRequest({ query: VerifyInvitationQuerySchema }),
+  asyncHandler(verifyInvitationController)
+);
+usersRouter.post(
+  '/invitations/accept',
+  validateRequest({ body: AcceptInvitationBodySchema }),
+  asyncHandler(acceptInvitationController)
 );
 usersRouter.delete(
   '/:id',

--- a/src/modules/users/users.service.ts
+++ b/src/modules/users/users.service.ts
@@ -1,6 +1,9 @@
 import { AppError } from '../../shared/http/errors.js';
 import { createUser, findUserByEmail } from './users.repo.js';
 import { UserModel } from './users.model.js';
+import jwt from 'jsonwebtoken';
+import { env } from '../../env.js';
+import { UserRole } from '../../shared/constants/index.js';
 
 export async function registerUser(input: { email: string; name: string }) {
   const existing = await findUserByEmail(input.email);
@@ -11,5 +14,111 @@ export async function registerUser(input: { email: string; name: string }) {
 export async function deleteUser(id: string) {
   const user = await UserModel.findByIdAndUpdate(id, { deletedAt: new Date() }, { new: true });
   if (!user) throw new AppError(404, 'User not found', 'USER_NOT_FOUND');
+  return user;
+}
+
+const INVITE_EXPIRY_SECONDS = 48 * 60 * 60;
+const INVITE_LINK_BASE_URL = 'https://app.navin.local/signup';
+
+type InviteTokenPayload = {
+  type: 'USER_INVITATION';
+  email: string;
+  role: string;
+  organizationId: string;
+  invitedBy: string;
+};
+
+export async function generateInvitationLink(input: {
+  email: string;
+  role: string;
+  inviterUserId: string;
+  inviterRole?: string;
+  organizationId?: string;
+}) {
+  if (!input.organizationId) {
+    throw new AppError(403, 'Organization context is required', 'FORBIDDEN');
+  }
+
+  if (!input.inviterRole) {
+    throw new AppError(403, 'Forbidden: insufficient role', 'FORBIDDEN');
+  }
+
+  if (input.role === UserRole.SUPER_ADMIN) {
+    throw new AppError(400, 'Cannot invite SUPER_ADMIN users', 'INVALID_ROLE');
+  }
+
+  const allowedByRole: Record<string, string[]> = {
+    [UserRole.SUPER_ADMIN]: [UserRole.ADMIN, UserRole.MANAGER, UserRole.VIEWER, UserRole.CUSTOMER],
+    [UserRole.ADMIN]: [UserRole.MANAGER, UserRole.VIEWER, UserRole.CUSTOMER],
+  };
+
+  const allowedTargetRoles = allowedByRole[input.inviterRole] ?? [];
+  if (!allowedTargetRoles.includes(input.role)) {
+    throw new AppError(403, 'Forbidden: insufficient role', 'FORBIDDEN');
+  }
+
+  const existing = await findUserByEmail(input.email);
+  if (existing) {
+    throw new AppError(409, 'Email already in use', 'EMAIL_TAKEN');
+  }
+
+  const tokenPayload: InviteTokenPayload = {
+    type: 'USER_INVITATION',
+    email: input.email,
+    role: input.role,
+    organizationId: input.organizationId,
+    invitedBy: input.inviterUserId,
+  };
+
+  const token = jwt.sign(tokenPayload, env.JWT_SECRET, { expiresIn: INVITE_EXPIRY_SECONDS });
+  const inviteLink = `${INVITE_LINK_BASE_URL}?token=${encodeURIComponent(token)}`;
+
+  return { token, inviteLink, expiresInSeconds: INVITE_EXPIRY_SECONDS };
+}
+
+export function verifyInvitationToken(token: string) {
+  let payload: jwt.JwtPayload;
+
+  try {
+    payload = jwt.verify(token, env.JWT_SECRET) as jwt.JwtPayload;
+  } catch {
+    throw new AppError(401, 'Invalid or expired invitation token', 'UNAUTHORIZED');
+  }
+
+  if (payload.type !== 'USER_INVITATION') {
+    throw new AppError(401, 'Invalid invitation token', 'UNAUTHORIZED');
+  }
+
+  if (!payload.organizationId || !payload.email || !payload.role) {
+    throw new AppError(401, 'Invalid invitation token payload', 'UNAUTHORIZED');
+  }
+
+  const expiresAt = payload.exp ? new Date(payload.exp * 1000).toISOString() : null;
+
+  return {
+    email: String(payload.email),
+    role: String(payload.role),
+    organizationId: String(payload.organizationId),
+    invitedBy: payload.invitedBy ? String(payload.invitedBy) : null,
+    expiresAt,
+  };
+}
+
+export async function acceptInvitation(input: { token: string; name: string; password: string }) {
+  const invitation = verifyInvitationToken(input.token);
+
+  const existing = await findUserByEmail(invitation.email);
+  if (existing) {
+    throw new AppError(409, 'Email already in use', 'EMAIL_TAKEN');
+  }
+
+  const user = await UserModel.create({
+    email: invitation.email,
+    name: input.name,
+    passwordHash: input.password,
+    role: invitation.role,
+    organizationId: invitation.organizationId,
+  });
+
   return user;
 }

--- a/src/modules/users/users.validation.ts
+++ b/src/modules/users/users.validation.ts
@@ -1,6 +1,22 @@
 import { z } from 'zod';
+import { UserRole } from '../../shared/constants/index.js';
 
 export const CreateUserBodySchema = z.object({
   email: z.string().email(),
   name: z.string().min(1),
+});
+
+export const CreateInvitationBodySchema = z.object({
+  email: z.string().email(),
+  role: z.nativeEnum(UserRole),
+});
+
+export const VerifyInvitationQuerySchema = z.object({
+  token: z.string().trim().min(1),
+});
+
+export const AcceptInvitationBodySchema = z.object({
+  token: z.string().trim().min(1),
+  name: z.string().trim().min(1),
+  password: z.string().min(6),
 });

--- a/tests/users.invitation.service.test.ts
+++ b/tests/users.invitation.service.test.ts
@@ -1,0 +1,89 @@
+import { beforeEach, describe, expect, it, jest } from '@jest/globals';
+
+describe('users invitation service', () => {
+  beforeEach(() => {
+    jest.resetModules();
+    jest.clearAllMocks();
+  });
+
+  it('generates and verifies a token bound to organization and role', async () => {
+    const findUserByEmail = jest.fn(async () => null);
+
+    await jest.unstable_mockModule('../src/modules/users/users.repo.js', () => ({
+      createUser: jest.fn(),
+      findUserByEmail,
+    }));
+
+    await jest.unstable_mockModule('../src/modules/users/users.model.js', () => ({
+      UserModel: {
+        findByIdAndUpdate: jest.fn(),
+        create: jest.fn(),
+      },
+    }));
+
+    const service = await import('../src/modules/users/users.service.js');
+
+    const invitation = await service.generateInvitationLink({
+      email: 'new.user@example.com',
+      role: 'MANAGER',
+      inviterUserId: 'admin-1',
+      inviterRole: 'ADMIN',
+      organizationId: 'org-1',
+    });
+
+    expect(invitation.inviteLink).toContain('token=');
+    expect(invitation.expiresInSeconds).toBe(172800);
+
+    const verified = service.verifyInvitationToken(invitation.token);
+    expect(verified.email).toBe('new.user@example.com');
+    expect(verified.role).toBe('MANAGER');
+    expect(verified.organizationId).toBe('org-1');
+    expect(verified.expiresAt).toBeTruthy();
+  });
+
+  it('rejects invitation creation for forbidden role mapping', async () => {
+    await jest.unstable_mockModule('../src/modules/users/users.repo.js', () => ({
+      createUser: jest.fn(),
+      findUserByEmail: jest.fn(async () => null),
+    }));
+
+    await jest.unstable_mockModule('../src/modules/users/users.model.js', () => ({
+      UserModel: {
+        findByIdAndUpdate: jest.fn(),
+        create: jest.fn(),
+      },
+    }));
+
+    const service = await import('../src/modules/users/users.service.js');
+
+    await expect(
+      service.generateInvitationLink({
+        email: 'admin2@example.com',
+        role: 'ADMIN',
+        inviterUserId: 'admin-1',
+        inviterRole: 'ADMIN',
+        organizationId: 'org-1',
+      }),
+    ).rejects.toThrow('Forbidden: insufficient role');
+  });
+
+  it('rejects invalid invitation tokens', async () => {
+    await jest.unstable_mockModule('../src/modules/users/users.repo.js', () => ({
+      createUser: jest.fn(),
+      findUserByEmail: jest.fn(async () => null),
+    }));
+
+    await jest.unstable_mockModule('../src/modules/users/users.model.js', () => ({
+      UserModel: {
+        findByIdAndUpdate: jest.fn(),
+        create: jest.fn(),
+      },
+    }));
+
+    const service = await import('../src/modules/users/users.service.js');
+
+    expect(() => service.verifyInvitationToken('not-a-token')).toThrow(
+      'Invalid or expired invitation token',
+    );
+  });
+});


### PR DESCRIPTION
Closes #174

## Summary
- add invitation link generation route with org and role binding
- add invitation token verification and acceptance routes
- enforce 48-hour token expiry via signed JWT invites
- add unit tests for invitation token generation/verification
- update swagger docs for invitation endpoints

## Validation
- npm run build
- npm test