### PR TITLE
[#171] [Optimization] Optimize Average Delivery Time Aggregation pipelines in MongoDB

### DIFF
--- a/src/modules/analytics/analytics.service.ts
+++ b/src/modules/analytics/analytics.service.ts
@@ -42,8 +42,25 @@ export async function getAnalyticsPerformance(
       $project: {
         status: 1,
         logisticsId: 1,
-        milestones: 1,
         createdAt: 1,
+        deliveredTimestamp: {
+          $arrayElemAt: [
+            {
+              $map: {
+                input: {
+                  $filter: {
+                    input: '$milestones',
+                    as: 'milestone',
+                    cond: { $eq: ['$$milestone.name', 'DELIVERED'] },
+                  },
+                },
+                as: 'deliveredMilestone',
+                in: '$$deliveredMilestone.timestamp',
+              },
+            },
+            0,
+          ],
+        },
       },
     },
     {
@@ -57,14 +74,12 @@ export async function getAnalyticsPerformance(
           },
         ],
         averageDeliveryTimeByLogisticsId: [
-          { $match: { 'milestones.name': 'DELIVERED' } },
-          { $unwind: '$milestones' },
-          { $match: { 'milestones.name': 'DELIVERED' } },
+          { $match: { deliveredTimestamp: { $ne: null } } },
           {
             $group: {
               _id: '$logisticsId',
               averageDeliveryTimeMs: {
-                $avg: { $subtract: ['$milestones.timestamp', '$createdAt'] },
+                $avg: { $subtract: ['$deliveredTimestamp', '$createdAt'] },
               },
             },
           },

--- a/src/modules/shipments/shipments.model.ts
+++ b/src/modules/shipments/shipments.model.ts
@@ -40,6 +40,7 @@ ShipmentSchema.index({ status: 1, createdAt: -1 });
 ShipmentSchema.index({ enterpriseId: 1, createdAt: -1 });
 ShipmentSchema.index({ logisticsId: 1, createdAt: -1 });
 ShipmentSchema.index({ createdAt: -1, _id: -1 });
+ShipmentSchema.index({ createdAt: -1, logisticsId: 1, 'milestones.name': 1 });
 
 // Soft delete middleware
 ShipmentSchema.pre(['find', 'findOne', 'findOneAndUpdate', 'countDocuments'], function () {

--- a/tests/analytics.performance.test.ts
+++ b/tests/analytics.performance.test.ts
@@ -54,9 +54,11 @@ describe('GET /api/analytics/performance', () => {
   ];
 
   let app: Application;
+  let capturedPipeline: Array<Record<string, unknown>> = [];
 
   beforeEach(async () => {
     const mockAggregate = jest.fn(async (pipeline: Array<Record<string, unknown>>) => {
+      capturedPipeline = pipeline;
       // Very small, purpose-built aggregation evaluator for this test.
       const matchStage = pipeline.find((s) => '$match' in s)?.$match as
         | { createdAt?: { $gte: Date; $lte: Date } }
@@ -153,6 +155,10 @@ describe('GET /api/analytics/performance', () => {
     );
 
     expect(res.body.data.totalDelayedShipments).toBe(2);
+
+    const serializedPipeline = JSON.stringify(capturedPipeline);
+    expect(serializedPipeline).not.toContain('$unwind');
+    expect(serializedPipeline).toContain('deliveredTimestamp');
   });
 
   it('returns 403 when role is not ADMIN or MANAGER', async () => {


### PR DESCRIPTION
Closes #171

## Summary
- replace unwind-based delivered milestone scan with filtered projection + deliveredTimestamp
- compute average delivery duration using deliveredTimestamp minus createdAt
- add compound shipment index for createdAt/logisticsId/milestones.name access pattern
- add assertion that optimized pipeline avoids unwind

## Validation
- npm run build
- npm test