### PR TITLE
[#172] [Optimization] Cache historical delayed counts in Redis

### DIFF
--- a/src/modules/analytics/analytics.cache.ts
+++ b/src/modules/analytics/analytics.cache.ts
@@ -1,0 +1,95 @@
+import { getRedisClient } from '../../infra/redis/connection.js';
+import type { AnalyticsDashboardPayload } from './analytics.service.js';
+
+const ANALYTICS_CACHE_PREFIX = 'analytics:performance:';
+const ANALYTICS_CACHE_TTL_SECONDS = 300;
+let redisUnavailable = false;
+
+type RedisLike = {
+  get: (key: string) => Promise<string | null>;
+  set: (...args: unknown[]) => Promise<unknown>;
+  scan: (...args: unknown[]) => Promise<[string, string[]]>;
+  del: (...keys: string[]) => Promise<number>;
+};
+
+function getCacheClient(): RedisLike | null {
+  if (redisUnavailable) {
+    return null;
+  }
+
+  try {
+    return getRedisClient() as unknown as RedisLike;
+  } catch {
+    redisUnavailable = true;
+    return null;
+  }
+}
+
+export function analyticsPerformanceCacheKey(startDateIso: string, endDateIso: string): string {
+  return `${ANALYTICS_CACHE_PREFIX}${startDateIso}:${endDateIso}`;
+}
+
+export async function readAnalyticsPerformanceCache(
+  key: string
+): Promise<AnalyticsDashboardPayload | null> {
+  const client = getCacheClient();
+  if (!client) {
+    return null;
+  }
+
+  try {
+    const value = await client.get(key);
+    if (!value) {
+      return null;
+    }
+    return JSON.parse(value) as AnalyticsDashboardPayload;
+  } catch {
+    redisUnavailable = true;
+    return null;
+  }
+}
+
+export async function writeAnalyticsPerformanceCache(
+  key: string,
+  payload: AnalyticsDashboardPayload
+): Promise<void> {
+  const client = getCacheClient();
+  if (!client) {
+    return;
+  }
+
+  try {
+    await client.set(key, JSON.stringify(payload), 'EX', ANALYTICS_CACHE_TTL_SECONDS);
+  } catch {
+    redisUnavailable = true;
+  }
+}
+
+export async function invalidateAnalyticsPerformanceCache(): Promise<void> {
+  const client = getCacheClient();
+  if (!client) {
+    return;
+  }
+
+  try {
+    let cursor = '0';
+
+    do {
+      const [nextCursor, keys] = await client.scan(
+        cursor,
+        'MATCH',
+        `${ANALYTICS_CACHE_PREFIX}*`,
+        'COUNT',
+        '100'
+      );
+
+      if (keys.length > 0) {
+        await client.del(...keys);
+      }
+
+      cursor = nextCursor;
+    } while (cursor !== '0');
+  } catch {
+    redisUnavailable = true;
+  }
+}

--- a/src/modules/analytics/analytics.service.ts
+++ b/src/modules/analytics/analytics.service.ts
@@ -1,4 +1,9 @@
 import { Shipment } from '../shipments/shipments.model.js';
+import {
+  analyticsPerformanceCacheKey,
+  readAnalyticsPerformanceCache,
+  writeAnalyticsPerformanceCache,
+} from './analytics.cache.js';
 
 import type { PerformanceQuery } from './analytics.validation.js';
 
@@ -30,6 +35,12 @@ export async function getAnalyticsPerformance(
 ): Promise<AnalyticsDashboardPayload> {
   const startDate = query.startDate;
   const endDate = query.endDate;
+  const cacheKey = analyticsPerformanceCacheKey(startDate.toISOString(), endDate.toISOString());
+
+  const cached = await readAnalyticsPerformanceCache(cacheKey);
+  if (cached) {
+    return cached;
+  }
 
   // Performance window is based on shipment `createdAt` (the document timestamp).
   const pipeline = [
@@ -97,11 +108,15 @@ export async function getAnalyticsPerformance(
 
   const totalDelayedShipments = Number(facet?.delayedShipments?.[0]?.totalDelayed ?? 0);
 
-  return {
+  const result = {
     startDate: startDate.toISOString(),
     endDate: endDate.toISOString(),
     shipmentsByStatus,
     averageDeliveryTimeByLogisticsId,
     totalDelayedShipments,
   };
+
+  await writeAnalyticsPerformanceCache(cacheKey, result);
+
+  return result;
 }

--- a/src/modules/shipments/shipments.service.ts
+++ b/src/modules/shipments/shipments.service.ts
@@ -6,6 +6,7 @@ import { UserModel } from '../users/users.model.js';
 import { emitStatusUpdate } from '../../infra/socket/io.js';
 import { IShipment, ShipmentStatus } from '../../shared/types/shipment.js';
 import { auditLog } from '../../shared/utils/auditLog.js';
+import { invalidateAnalyticsPerformanceCache } from '../analytics/analytics.cache.js';
 
 type ShipmentListResult = {
   data: IShipment[];
@@ -133,6 +134,7 @@ export const updateShipmentStatusService = async (
   shipment.milestones.push(milestone);
 
   await shipment.save();
+  await invalidateAnalyticsPerformanceCache();
 
   if (actor?.userId) {
     auditLog({

--- a/tests/analytics.cache.test.ts
+++ b/tests/analytics.cache.test.ts
@@ -1,0 +1,88 @@
+import { beforeEach, describe, expect, it, jest } from '@jest/globals';
+import jwt from 'jsonwebtoken';
+import request from 'supertest';
+import type { Application } from 'express';
+
+describe('analytics redis cache', () => {
+  let app: Application;
+
+  const cache = new Map<string, string>();
+  const redisGet = jest.fn(async (key: string) => cache.get(key) ?? null);
+  const redisSet = jest.fn(async (key: string, value: string) => {
+    cache.set(key, value);
+    return 'OK';
+  });
+  const redisScan = jest.fn(async () => ['0', [] as string[]]);
+  const redisDel = jest.fn(async () => 0);
+
+  const aggregateExecutions = { count: 0 };
+
+  beforeEach(async () => {
+    jest.resetModules();
+    jest.clearAllMocks();
+    cache.clear();
+    aggregateExecutions.count = 0;
+
+    await jest.unstable_mockModule('../src/infra/redis/connection.js', () => ({
+      getRedisClient: jest.fn(() => ({
+        get: redisGet,
+        set: redisSet,
+        scan: redisScan,
+        del: redisDel,
+      })),
+      redisConnection: {},
+    }));
+
+    const mockAggregate = jest.fn((pipeline: unknown) => ({
+      option: jest.fn(async () => {
+        aggregateExecutions.count += 1;
+        return [
+          {
+            shipmentsByStatus: [{ _id: 'DELIVERED', total: 4 }],
+            averageDeliveryTimeByLogisticsId: [{ _id: 'log-1', averageDeliveryTimeMs: 2000 }],
+            delayedShipments: [{ totalDelayed: 1 }],
+          },
+        ];
+      }),
+    }));
+
+    await jest.unstable_mockModule('../src/modules/shipments/shipments.model.js', () => ({
+      Shipment: {
+        aggregate: mockAggregate,
+      },
+      ShipmentStatus: {
+        CREATED: 'CREATED',
+        IN_TRANSIT: 'IN_TRANSIT',
+        DELIVERED: 'DELIVERED',
+        CANCELLED: 'CANCELLED',
+      },
+    }));
+
+    const appModule = await import('../src/app.js');
+    app = appModule.buildApp();
+  });
+
+  it('serves second performance request from redis cache without hitting aggregation again', async () => {
+    const token = jwt.sign({ userId: 'u1', role: 'ADMIN' }, process.env.JWT_SECRET!);
+    const query = {
+      startDate: '2026-01-01T00:00:00.000Z',
+      endDate: '2026-01-31T23:59:59.999Z',
+    };
+
+    const first = await request(app)
+      .get('/api/analytics/performance')
+      .query(query)
+      .set('Authorization', `Bearer ${token}`);
+
+    const second = await request(app)
+      .get('/api/analytics/performance')
+      .query(query)
+      .set('Authorization', `Bearer ${token}`);
+
+    expect(first.status).toBe(200);
+    expect(second.status).toBe(200);
+    expect(aggregateExecutions.count).toBe(1);
+    expect(redisSet).toHaveBeenCalledTimes(1);
+    expect(redisGet).toHaveBeenCalledTimes(2);
+  });
+});

--- a/tests/shipments.status-cache-invalidation.test.ts
+++ b/tests/shipments.status-cache-invalidation.test.ts
@@ -1,0 +1,62 @@
+import { beforeEach, describe, expect, it, jest } from '@jest/globals';
+
+describe('shipment status cache invalidation', () => {
+  beforeEach(() => {
+    jest.resetModules();
+    jest.clearAllMocks();
+  });
+
+  it('invalidates analytics cache when shipment status changes', async () => {
+    const save = jest.fn(async () => undefined);
+    const shipmentDoc = {
+      _id: 'shipment-1',
+      status: 'CREATED',
+      milestones: [] as Array<Record<string, unknown>>,
+      updatedAt: new Date(),
+      save,
+    };
+
+    const invalidateAnalyticsPerformanceCache = jest.fn(async () => undefined);
+    const emitStatusUpdate = jest.fn();
+
+    await jest.unstable_mockModule('../src/modules/shipments/shipments.model.js', () => ({
+      Shipment: {
+        findById: jest.fn(async () => shipmentDoc),
+        find: jest.fn(),
+      },
+      ShipmentStatus: {
+        CREATED: 'CREATED',
+        IN_TRANSIT: 'IN_TRANSIT',
+        DELIVERED: 'DELIVERED',
+        CANCELLED: 'CANCELLED',
+      },
+    }));
+
+    await jest.unstable_mockModule('../src/modules/users/users.model.js', () => ({
+      UserModel: {
+        findById: jest.fn(),
+      },
+    }));
+
+    await jest.unstable_mockModule('../src/infra/socket/io.js', () => ({
+      emitStatusUpdate,
+    }));
+
+    await jest.unstable_mockModule('../src/modules/analytics/analytics.cache.js', () => ({
+      invalidateAnalyticsPerformanceCache,
+    }));
+
+    await jest.unstable_mockModule('../src/shared/utils/auditLog.js', () => ({
+      auditLog: jest.fn(),
+    }));
+
+    const { updateShipmentStatusService } = await import('../src/modules/shipments/shipments.service.js');
+
+    const result = await updateShipmentStatusService('shipment-1', 'DELIVERED' as any);
+
+    expect(result).toBeTruthy();
+    expect(invalidateAnalyticsPerformanceCache).toHaveBeenCalledTimes(1);
+    expect(save).toHaveBeenCalledTimes(1);
+    expect(emitStatusUpdate).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
Closes #172

## Summary
- add Redis-backed analytics performance cache with 5-minute TTL
- read cached dashboard data on subsequent performance requests
- invalidate analytics cache automatically when shipment status changes
- add tests proving second request avoids aggregate query and status changes invalidate cache

## Validation
- npm run build
- npm test