### PR TITLE
refactor: centralize password hashing and remove User model pre-save hook

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,21 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
+
+## [Unreleased]
+
+### Fixed
+- Double-hashing bug: removed the `UserSchema.pre('save')` password hook that caused `bcrypt` to hash an already-hashed value during signup, making all post-signup logins fail (#48)
+- `acceptInvitation` now hashes the raw password in the service layer before `UserModel.create()`, consistent with all other flows (#48)
+
+### Security
+- `createTeamMember` no longer stores an empty string as `passwordHash`; a cryptographically random bcrypt hash is stored instead, ensuring `bcrypt.compare(anyInput, placeholder)` always returns `false` until the user completes the invitation flow (#48)
+
+### Changed
+- Password hashing is now exclusively the responsibility of the service layer (`auth.service.ts`, `users.service.ts`). The `UserSchema` pre-save hook has been removed to enforce a single hashing strategy (#48)
+- Removed `bcrypt` import from `users.model.ts` (no longer needed) (#48)
+
+### Tests
+- Added `tests/password-hashing.test.ts` covering signup, invitation acceptance, team member creation, and login round-trip scenarios (#48)

--- a/package-lock.json
+++ b/package-lock.json
@@ -92,6 +92,7 @@
       "integrity": "sha512-RgHBCvtjbOK2gXSNBNIkNoEc9qoVEtau3hj8gEqKQuL3HZAibKarWFEI3Lfm6EYKkLalOh8eSrj9b+ch9H/VBA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.7",
         "@babel/generator": "^7.29.7",
@@ -594,29 +595,6 @@
       "optional": true,
       "engines": {
         "node": ">=0.1.90"
-      }
-    },
-    "node_modules/@emnapi/core": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
-      "integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "@emnapi/wasi-threads": "1.2.1",
-        "tslib": "^2.4.0"
-      }
-    },
-    "node_modules/@emnapi/runtime": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
-      "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "tslib": "^2.4.0"
       }
     },
     "node_modules/@emnapi/wasi-threads": {
@@ -2477,6 +2455,7 @@
       "integrity": "sha512-fcqpj/MyK4sxDPcbe7STNPbpQL4RLZOPWuaTmwZYuc+hJKzRf58yRxfhqGpc6PIq9ZyfSBpfHgmUHmHs0KwHwg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.60.0",
         "@typescript-eslint/types": "8.60.0",
@@ -3014,6 +2993,7 @@
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -3348,6 +3328,7 @@
       "integrity": "sha512-HdUm8EMQBLaJvGUdidNNbqpA1kYkwNcb+MYxkxCLAPJGQzlv9J0C24h8V65Z4c5GLd/JEALDvpFCQgpLJqc0zw==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "peerDependencies": {
         "bare-abort-controller": "*"
       },
@@ -3603,6 +3584,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.10.12",
         "caniuse-lite": "^1.0.30001782",
@@ -4773,6 +4755,7 @@
       "integrity": "sha512-loXy6bWOoP3EP6JA7jo6p5jMpBJmHmsNZM5SFRHLdh1MGOPurMnNBj4ZlAbaqUAaQWbCr7jHV4P7gzAyryZWkQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.2",
@@ -4829,6 +4812,7 @@
       "integrity": "sha512-82GZUjRS0p/jganf6q1rEO25VSoHH0hKPCTrgillPjdI/3bgBhAE1QzHrHTizjpRvy6pGAvKjDJtk2pF9NDq8w==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "eslint-config-prettier": "bin/cli.js"
       },
@@ -5115,6 +5099,7 @@
       "resolved": "https://registry.npmjs.org/express/-/express-4.22.2.tgz",
       "integrity": "sha512-IuL+Elrou2ZvCFHs18/CIzy2Nzvo25nZ1/D2eIZlz7c+QUayAcYoiM2BthCjs+EBHVpjYjcuLDAiCWgeIX3X1Q==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "accepts": "~1.3.8",
         "array-flatten": "1.1.1",
@@ -5281,6 +5266,7 @@
       "integrity": "sha512-0DS4Nn4rV8qyFlQCpKK8brT61EUtswynrpfFTcgLErcilBIBskSMQ86fO2WVuybr14ywyKdRjv91FiRZwnEuvQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "readline-sync": "^1.4.10",
         "sprintf-js": "^1.1.3",
@@ -6023,6 +6009,7 @@
       "resolved": "https://registry.npmjs.org/ioredis/-/ioredis-5.11.0.tgz",
       "integrity": "sha512-EZBErytyVovD8f6pDfG3Kb37N6Y3lmDA9NNj+4+IP13CzzHGeX+OyeRM2Um13khRzoBSzzL+5lVnCX8V2RLeMg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@ioredis/commands": "1.10.0",
         "cluster-key-slot": "1.1.1",
@@ -6293,6 +6280,7 @@
       "integrity": "sha512-Yi1jqNC/Oq0N4hBgNH/YvBpP1P57QqundgytzYqy3yqAa7NZPNjSoi4SGbRAXDMdBzNE6xBCi5U7RgfrvMEUVQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@jest/core": "30.4.2",
         "@jest/types": "30.4.1",
@@ -7578,6 +7566,7 @@
       "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-6.21.0.tgz",
       "integrity": "sha512-URyb/VXMjJ4da46OeSXg+puO39XH9DeQpWCslifrRn9JWugy0D+DvvBvkm2WxmHe61O/H19JM66p1z7RHVkZ6A==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@mongodb-js/saslprep": "^1.3.0",
         "bson": "^6.10.4",
@@ -8288,6 +8277,7 @@
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -8484,6 +8474,7 @@
       "integrity": "sha512-7igPTM53cGHMW8xWuVTydi2KO233VFiTNyF5hLJqpilHfmn8C8gPf+PS7dUT64YcXFbiMGZxS9pCSxL/Dxm/Jw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "prettier": "bin/prettier.cjs"
       },
@@ -9982,6 +9973,7 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"

--- a/src/modules/users/users.model.ts
+++ b/src/modules/users/users.model.ts
@@ -1,5 +1,4 @@
 import mongoose from 'mongoose';
-import bcrypt from 'bcrypt';
 import { isoDatePlugin } from '../../shared/plugins/isoDatePlugin.js';
 import { IOrganization, OrganizationType, IUser, UserRole } from '../../shared/types/user.js';
 
@@ -37,14 +36,9 @@ const UserSchema = new mongoose.Schema(
 
 UserSchema.plugin(isoDatePlugin);
 
-// Pre-save hook to hash password
-UserSchema.pre('save', async function (next) {
-  if (this.isModified('passwordHash')) {
-    const salt = await bcrypt.genSalt(10);
-    this.passwordHash = await bcrypt.hash(this.passwordHash, salt);
-  }
-  next();
-});
+// NOTE: Password hashing is performed exclusively in the service layer (auth.service.ts,
+// users.service.ts) before calling UserModel.create(). There is intentionally no pre-save
+// hook here to avoid double-hashing.
 
 // Override toJSON to hide passwordHash
 UserSchema.methods.toJSON = function () {

--- a/src/modules/users/users.service.ts
+++ b/src/modules/users/users.service.ts
@@ -1,3 +1,5 @@
+import bcrypt from 'bcrypt';
+import { randomBytes } from 'crypto';
 import { AppError } from '../../shared/http/errors.js';
 import { createUser, findUserByEmail, findUsersByOrganizationId } from './users.repo.js';
 import { UserModel } from './users.model.js';
@@ -32,11 +34,16 @@ export async function createTeamMember(input: {
   const existing = await findUserByEmail(input.email);
   if (existing) throw new AppError(409, 'Email already in use', 'EMAIL_TAKEN');
 
+  // Team members have no password until they complete the invitation flow.
+  // Store a random bcrypt hash so bcrypt.compare(anything, placeholder) always
+  // returns false — preventing accidental authentication.
+  const lockedHash = await bcrypt.hash(randomBytes(32).toString('hex'), 10);
+
   // Force override organizationId from caller's JWT context
   return createUser({
     email: input.email,
     name: input.name,
-    passwordHash: '', // Will be set later via invitation flow or direct password
+    passwordHash: lockedHash,
     role: input.role || UserRole.VIEWER,
     organizationId: input.callerOrganizationId, // Override with caller's org
   });
@@ -194,10 +201,13 @@ export async function acceptInvitation(input: { token: string; name: string; pas
     throw new AppError(409, 'Email already in use', 'EMAIL_TAKEN');
   }
 
+  // Hash the raw password in the service layer — the model has no pre-save hook.
+  const passwordHash = await bcrypt.hash(input.password, 10);
+
   const user = await UserModel.create({
     email: invitation.email,
     name: input.name,
-    passwordHash: input.password,
+    passwordHash,
     role: invitation.role,
     organizationId: invitation.organizationId,
   });

--- a/tests/auth.test.ts
+++ b/tests/auth.test.ts
@@ -42,6 +42,13 @@ jest.unstable_mockModule('../src/modules/users/users.model.js', () => ({
     ENTERPRISE: 'ENTERPRISE',
     LOGISTICS: 'LOGISTICS',
   },
+  UserRole: {
+    SUPER_ADMIN: 'SUPER_ADMIN',
+    ADMIN: 'ADMIN',
+    MANAGER: 'MANAGER',
+    VIEWER: 'VIEWER',
+    CUSTOMER: 'CUSTOMER',
+  },
 }));
 
 const { env } = await import('../src/env.js');

--- a/tests/password-hashing.test.ts
+++ b/tests/password-hashing.test.ts
@@ -1,0 +1,482 @@
+/**
+ * Tests for Issue #48 — Password hashing consistency.
+ *
+ * Verifies that:
+ * 1. Signup hashes the password exactly once (service layer only).
+ * 2. Invitation acceptance hashes the password exactly once (service layer only).
+ * 3. Team members created without a password cannot authenticate.
+ *
+ * All DB and JWT operations are mocked; only bcrypt calls are real
+ * to exercise the actual hashing logic end-to-end.
+ */
+import bcrypt from 'bcrypt';
+import { jest, describe, it, expect, beforeEach } from '@jest/globals';
+import { randomBytes } from 'crypto';
+
+// ---------------------------------------------------------------------------
+// Shared mock factories
+// ---------------------------------------------------------------------------
+
+function makeUserDoc(overrides: Record<string, unknown> = {}) {
+  return {
+    _id: { toString: () => 'user-id-123' },
+    email: 'test@example.com',
+    name: 'Test User',
+    role: 'VIEWER',
+    organizationId: { toString: () => 'org-id-1' },
+    ...overrides,
+  };
+}
+
+/** Build a full users.model.js mock that includes all named exports auth.service.ts needs. */
+function makeModelMock(
+  mockCreate: jest.Mock,
+  mockFindOne: jest.Mock,
+  mockOrgFindById: jest.Mock,
+) {
+  return {
+    UserModel: { create: mockCreate, findOne: mockFindOne },
+    OrganizationModel: { findById: mockOrgFindById },
+    OrganizationType: {
+      ENTERPRISE: 'ENTERPRISE',
+      LOGISTICS: 'LOGISTICS',
+      SUPPLY_CHAIN: 'SUPPLY_CHAIN',
+    },
+    UserRole: {
+      SUPER_ADMIN: 'SUPER_ADMIN',
+      ADMIN: 'ADMIN',
+      MANAGER: 'MANAGER',
+      VIEWER: 'VIEWER',
+      CUSTOMER: 'CUSTOMER',
+    },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Signup flow
+// ---------------------------------------------------------------------------
+
+describe('Password hashing — signup flow', () => {
+  beforeEach(() => {
+    jest.resetModules();
+  });
+
+  it('stores a bcrypt hash (not plaintext) for a new signup', async () => {
+    let capturedPasswordHash = '';
+
+    const mockCreate = jest.fn<(...args: unknown[]) => Promise<ReturnType<typeof makeUserDoc>>>(
+      async (...args) => {
+        const doc = args[0] as Record<string, unknown>;
+        capturedPasswordHash = doc['passwordHash'] as string;
+        return makeUserDoc({ passwordHash: doc['passwordHash'] });
+      },
+    );
+    const mockFindOne = jest.fn<(...args: unknown[]) => Promise<null>>().mockResolvedValue(null);
+    const mockOrgFindById = jest
+      .fn<(...args: unknown[]) => Promise<null>>()
+      .mockResolvedValue(null);
+
+    jest.unstable_mockModule(
+      '../src/modules/users/users.model.js',
+      () => makeModelMock(mockCreate, mockFindOne, mockOrgFindById),
+    );
+
+    const { signup } = await import('../src/modules/auth/auth.service.js');
+
+    await signup({
+      email: 'test@example.com',
+      name: 'Test User',
+      password: 'plaintext123',
+      organizationId: 'org-id-1',
+    });
+
+    // Must be a bcrypt hash — not the original plaintext
+    expect(capturedPasswordHash).not.toBe('plaintext123');
+    expect(capturedPasswordHash.startsWith('$2')).toBe(true);
+
+    // bcrypt.compare must verify correctly (single hash round)
+    const isValid = await bcrypt.compare('plaintext123', capturedPasswordHash);
+    expect(isValid).toBe(true);
+  });
+
+  it('hashed value is NOT double-hashed (bcrypt.compare succeeds on single hash)', async () => {
+    // If the old bug were present, capturedPasswordHash would be a bcrypt hash of a
+    // bcrypt hash, and bcrypt.compare('plaintext', doubleHashed) would return false.
+    let capturedPasswordHash = '';
+
+    const mockCreate = jest.fn<(...args: unknown[]) => Promise<ReturnType<typeof makeUserDoc>>>(
+      async (...args) => {
+        const doc = args[0] as Record<string, unknown>;
+        capturedPasswordHash = doc['passwordHash'] as string;
+        return makeUserDoc({ passwordHash: doc['passwordHash'] });
+      },
+    );
+    const mockFindOne = jest.fn<(...args: unknown[]) => Promise<null>>().mockResolvedValue(null);
+    const mockOrgFindById = jest
+      .fn<(...args: unknown[]) => Promise<null>>()
+      .mockResolvedValue(null);
+
+    jest.unstable_mockModule(
+      '../src/modules/users/users.model.js',
+      () => makeModelMock(mockCreate, mockFindOne, mockOrgFindById),
+    );
+
+    const { signup } = await import('../src/modules/auth/auth.service.js');
+
+    await signup({
+      email: 'user2@example.com',
+      name: 'Another User',
+      password: 'mySecurePass!',
+      organizationId: 'org-id-1',
+    });
+
+    const isValid = await bcrypt.compare('mySecurePass!', capturedPasswordHash);
+    expect(isValid).toBe(true); // would fail if double-hashed
+  });
+
+  it('throws 409 when email is already in use', async () => {
+    const mockCreate = jest
+      .fn<(...args: unknown[]) => Promise<ReturnType<typeof makeUserDoc>>>()
+      .mockResolvedValue(makeUserDoc());
+    const mockFindOne = jest
+      .fn<(...args: unknown[]) => Promise<ReturnType<typeof makeUserDoc>>>()
+      .mockResolvedValue(makeUserDoc({ email: 'taken@example.com' }));
+    const mockOrgFindById = jest
+      .fn<(...args: unknown[]) => Promise<null>>()
+      .mockResolvedValue(null);
+
+    jest.unstable_mockModule(
+      '../src/modules/users/users.model.js',
+      () => makeModelMock(mockCreate, mockFindOne, mockOrgFindById),
+    );
+
+    const { signup } = await import('../src/modules/auth/auth.service.js');
+
+    await expect(
+      signup({ email: 'taken@example.com', name: 'X', password: 'pass', organizationId: 'org-1' }),
+    ).rejects.toThrow('Email already in use');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Invitation acceptance flow
+// ---------------------------------------------------------------------------
+
+describe('Password hashing — invitation acceptance flow', () => {
+  beforeEach(() => {
+    jest.resetModules();
+  });
+
+  it('stores a bcrypt hash after invitation acceptance', async () => {
+    let capturedPasswordHash = '';
+
+    const mockCreate = jest.fn<(...args: unknown[]) => Promise<ReturnType<typeof makeUserDoc>>>(
+      async (...args) => {
+        const doc = args[0] as Record<string, unknown>;
+        capturedPasswordHash = doc['passwordHash'] as string;
+        return makeUserDoc({ passwordHash: doc['passwordHash'] });
+      },
+    );
+
+    jest.unstable_mockModule('../src/modules/users/users.repo.js', () => ({
+      createUser: jest.fn(),
+      findUserByEmail: jest.fn<(...args: unknown[]) => Promise<null>>().mockResolvedValue(null),
+      findUsersByOrganizationId: jest.fn(),
+    }));
+
+    jest.unstable_mockModule('../src/modules/users/users.model.js', () => ({
+      UserModel: { create: mockCreate },
+      UserRole: {
+        SUPER_ADMIN: 'SUPER_ADMIN',
+        ADMIN: 'ADMIN',
+        MANAGER: 'MANAGER',
+        VIEWER: 'VIEWER',
+        CUSTOMER: 'CUSTOMER',
+      },
+    }));
+
+    const service = await import('../src/modules/users/users.service.js');
+
+    const invitation = await service.generateInvitationLink({
+      email: 'invited@example.com',
+      role: 'VIEWER',
+      inviterUserId: 'admin-1',
+      inviterRole: 'ADMIN',
+      organizationId: 'org-id-1',
+    });
+
+    await service.acceptInvitation({
+      token: invitation.token,
+      name: 'New Member',
+      password: 'InvitationPass99!',
+    });
+
+    expect(capturedPasswordHash).not.toBe('InvitationPass99!');
+    expect(capturedPasswordHash.startsWith('$2')).toBe(true);
+
+    const isValid = await bcrypt.compare('InvitationPass99!', capturedPasswordHash);
+    expect(isValid).toBe(true);
+  });
+
+  it('throws 409 when invited email is already registered', async () => {
+    const mockCreate = jest
+      .fn<(...args: unknown[]) => Promise<ReturnType<typeof makeUserDoc>>>()
+      .mockResolvedValue(makeUserDoc());
+
+    jest.unstable_mockModule('../src/modules/users/users.repo.js', () => ({
+      createUser: jest.fn(),
+      findUserByEmail: jest
+        .fn<(...args: unknown[]) => Promise<ReturnType<typeof makeUserDoc>>>()
+        .mockResolvedValue(makeUserDoc({ email: 'invited@example.com' })),
+      findUsersByOrganizationId: jest.fn(),
+    }));
+
+    jest.unstable_mockModule('../src/modules/users/users.model.js', () => ({
+      UserModel: { create: mockCreate },
+      UserRole: {
+        SUPER_ADMIN: 'SUPER_ADMIN',
+        ADMIN: 'ADMIN',
+        MANAGER: 'MANAGER',
+        VIEWER: 'VIEWER',
+        CUSTOMER: 'CUSTOMER',
+      },
+    }));
+
+    const service = await import('../src/modules/users/users.service.js');
+
+    const jwt = await import('jsonwebtoken');
+    const { env } = await import('../src/env.js');
+    const token = jwt.default.sign(
+      {
+        type: 'USER_INVITATION',
+        email: 'invited@example.com',
+        role: 'VIEWER',
+        organizationId: 'org-1',
+        invitedBy: 'admin-1',
+      },
+      env.JWT_SECRET,
+      { expiresIn: 3600 },
+    );
+
+    await expect(
+      service.acceptInvitation({ token, name: 'Dup User', password: 'pass123' }),
+    ).rejects.toThrow('Email already in use');
+  });
+
+  it('throws on invalid invitation token', async () => {
+    jest.unstable_mockModule('../src/modules/users/users.repo.js', () => ({
+      createUser: jest.fn(),
+      findUserByEmail: jest.fn<(...args: unknown[]) => Promise<null>>().mockResolvedValue(null),
+      findUsersByOrganizationId: jest.fn(),
+    }));
+
+    jest.unstable_mockModule('../src/modules/users/users.model.js', () => ({
+      UserModel: {
+        create: jest.fn<(...args: unknown[]) => Promise<ReturnType<typeof makeUserDoc>>>(),
+      },
+      UserRole: {
+        SUPER_ADMIN: 'SUPER_ADMIN',
+        ADMIN: 'ADMIN',
+        MANAGER: 'MANAGER',
+        VIEWER: 'VIEWER',
+        CUSTOMER: 'CUSTOMER',
+      },
+    }));
+
+    const service = await import('../src/modules/users/users.service.js');
+
+    await expect(
+      service.acceptInvitation({ token: 'not-a-valid-jwt', name: 'X', password: 'pass' }),
+    ).rejects.toThrow('Invalid or expired invitation token');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Team member creation flow
+// ---------------------------------------------------------------------------
+
+describe('Password hashing — team member creation flow', () => {
+  beforeEach(() => {
+    jest.resetModules();
+  });
+
+  it('stores a bcrypt-hashed placeholder (not empty string) for team members', async () => {
+    let capturedDoc: Record<string, unknown> = {};
+
+    const mockCreateUser = jest.fn<(...args: unknown[]) => Promise<ReturnType<typeof makeUserDoc>>>(
+      async (...args) => {
+        capturedDoc = args[0] as Record<string, unknown>;
+        return makeUserDoc(capturedDoc);
+      },
+    );
+
+    jest.unstable_mockModule('../src/modules/users/users.repo.js', () => ({
+      createUser: mockCreateUser,
+      findUserByEmail: jest.fn<(...args: unknown[]) => Promise<null>>().mockResolvedValue(null),
+      findUsersByOrganizationId: jest.fn(),
+    }));
+
+    jest.unstable_mockModule('../src/modules/users/users.model.js', () => ({
+      UserModel: {
+        create: jest.fn<(...args: unknown[]) => Promise<ReturnType<typeof makeUserDoc>>>(),
+      },
+      UserRole: {
+        SUPER_ADMIN: 'SUPER_ADMIN',
+        ADMIN: 'ADMIN',
+        MANAGER: 'MANAGER',
+        VIEWER: 'VIEWER',
+        CUSTOMER: 'CUSTOMER',
+      },
+    }));
+
+    const service = await import('../src/modules/users/users.service.js');
+
+    await service.createTeamMember({
+      email: 'member@example.com',
+      name: 'Team Member',
+      callerOrganizationId: 'org-id-1',
+    });
+
+    const capturedPasswordHash = capturedDoc['passwordHash'] as string;
+
+    // Must NOT be an empty string
+    expect(capturedPasswordHash).not.toBe('');
+
+    // Must be a valid bcrypt hash
+    expect(capturedPasswordHash.startsWith('$2')).toBe(true);
+
+    // No real password should match this random placeholder
+    const isValid = await bcrypt.compare('anyguess', capturedPasswordHash);
+    expect(isValid).toBe(false);
+  });
+
+  it('throws 409 if team member email is already registered', async () => {
+    const mockCreateUser = jest
+      .fn<(...args: unknown[]) => Promise<ReturnType<typeof makeUserDoc>>>()
+      .mockResolvedValue(makeUserDoc());
+
+    jest.unstable_mockModule('../src/modules/users/users.repo.js', () => ({
+      createUser: mockCreateUser,
+      findUserByEmail: jest
+        .fn<(...args: unknown[]) => Promise<ReturnType<typeof makeUserDoc>>>()
+        .mockResolvedValue(makeUserDoc({ email: 'taken@example.com' })),
+      findUsersByOrganizationId: jest.fn(),
+    }));
+
+    jest.unstable_mockModule('../src/modules/users/users.model.js', () => ({
+      UserModel: {
+        create: jest.fn<(...args: unknown[]) => Promise<ReturnType<typeof makeUserDoc>>>(),
+      },
+      UserRole: {
+        SUPER_ADMIN: 'SUPER_ADMIN',
+        ADMIN: 'ADMIN',
+        MANAGER: 'MANAGER',
+        VIEWER: 'VIEWER',
+        CUSTOMER: 'CUSTOMER',
+      },
+    }));
+
+    const service = await import('../src/modules/users/users.service.js');
+
+    await expect(
+      service.createTeamMember({
+        email: 'taken@example.com',
+        name: 'Dup',
+        callerOrganizationId: 'org-id-1',
+      }),
+    ).rejects.toMatchObject({ statusCode: 409, message: 'Email already in use' });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Login verification — end-to-end round-trip
+// ---------------------------------------------------------------------------
+
+describe('Password hashing — login round-trip', () => {
+  beforeEach(() => {
+    jest.resetModules();
+  });
+
+  it('login succeeds after signup with correct password', async () => {
+    const storedHash = await bcrypt.hash('testPassword1!', 10);
+
+    const mockFindOne = jest
+      .fn<(...args: unknown[]) => Promise<ReturnType<typeof makeUserDoc>>>()
+      .mockResolvedValue(makeUserDoc({ passwordHash: storedHash, organizationId: null }));
+    const mockCreate = jest
+      .fn<(...args: unknown[]) => Promise<ReturnType<typeof makeUserDoc>>>()
+      .mockResolvedValue(makeUserDoc());
+    const mockOrgFindById = jest
+      .fn<(...args: unknown[]) => Promise<null>>()
+      .mockResolvedValue(null);
+
+    jest.unstable_mockModule(
+      '../src/modules/users/users.model.js',
+      () => makeModelMock(mockCreate, mockFindOne, mockOrgFindById),
+    );
+
+    const { login } = await import('../src/modules/auth/auth.service.js');
+
+    const result = await login({ email: 'test@example.com', password: 'testPassword1!' });
+    expect(result).toHaveProperty('token');
+    expect(result.user.email).toBe('test@example.com');
+  });
+
+  it('login fails after signup with wrong password', async () => {
+    const storedHash = await bcrypt.hash('realPassword', 10);
+
+    const mockFindOne = jest
+      .fn<(...args: unknown[]) => Promise<ReturnType<typeof makeUserDoc>>>()
+      .mockResolvedValue(makeUserDoc({ passwordHash: storedHash, organizationId: null }));
+    const mockCreate = jest
+      .fn<(...args: unknown[]) => Promise<ReturnType<typeof makeUserDoc>>>()
+      .mockResolvedValue(makeUserDoc());
+    const mockOrgFindById = jest
+      .fn<(...args: unknown[]) => Promise<null>>()
+      .mockResolvedValue(null);
+
+    jest.unstable_mockModule(
+      '../src/modules/users/users.model.js',
+      () => makeModelMock(mockCreate, mockFindOne, mockOrgFindById),
+    );
+
+    const { login } = await import('../src/modules/auth/auth.service.js');
+
+    await expect(
+      login({ email: 'test@example.com', password: 'wrongPassword' }),
+    ).rejects.toThrow('Invalid credentials');
+  });
+
+  it('team member without a real password cannot authenticate (locked hash)', async () => {
+    // Simulate what createTeamMember stores: a random bcrypt hash of random bytes
+    const lockedHash = await bcrypt.hash(randomBytes(32).toString('hex'), 10);
+
+    const mockFindOne = jest
+      .fn<(...args: unknown[]) => Promise<ReturnType<typeof makeUserDoc>>>()
+      .mockResolvedValue(makeUserDoc({ passwordHash: lockedHash, organizationId: null }));
+    const mockCreate = jest
+      .fn<(...args: unknown[]) => Promise<ReturnType<typeof makeUserDoc>>>()
+      .mockResolvedValue(makeUserDoc());
+    const mockOrgFindById = jest
+      .fn<(...args: unknown[]) => Promise<null>>()
+      .mockResolvedValue(null);
+
+    jest.unstable_mockModule(
+      '../src/modules/users/users.model.js',
+      () => makeModelMock(mockCreate, mockFindOne, mockOrgFindById),
+    );
+
+    const { login } = await import('../src/modules/auth/auth.service.js');
+
+    await expect(
+      login({ email: 'member@example.com', password: '' }),
+    ).rejects.toThrow('Invalid credentials');
+
+    // Reset for next call (module cached, mock not reset)
+    mockFindOne.mockResolvedValue(makeUserDoc({ passwordHash: lockedHash, organizationId: null }));
+
+    await expect(
+      login({ email: 'member@example.com', password: 'anyguess123' }),
+    ).rejects.toThrow('Invalid credentials');
+  });
+});

--- a/tests/users.invitation.service.test.ts
+++ b/tests/users.invitation.service.test.ts
@@ -12,6 +12,7 @@ describe('users invitation service', () => {
     await jest.unstable_mockModule('../src/modules/users/users.repo.js', () => ({
       createUser: jest.fn(),
       findUserByEmail,
+      findUsersByOrganizationId: jest.fn(),
     }));
 
     await jest.unstable_mockModule('../src/modules/users/users.model.js', () => ({
@@ -45,6 +46,7 @@ describe('users invitation service', () => {
     await jest.unstable_mockModule('../src/modules/users/users.repo.js', () => ({
       createUser: jest.fn(),
       findUserByEmail: jest.fn(async () => null),
+      findUsersByOrganizationId: jest.fn(),
     }));
 
     await jest.unstable_mockModule('../src/modules/users/users.model.js', () => ({
@@ -71,6 +73,7 @@ describe('users invitation service', () => {
     await jest.unstable_mockModule('../src/modules/users/users.repo.js', () => ({
       createUser: jest.fn(),
       findUserByEmail: jest.fn(async () => null),
+      findUsersByOrganizationId: jest.fn(),
     }));
 
     await jest.unstable_mockModule('../src/modules/users/users.model.js', () => ({


### PR DESCRIPTION
The bug stemmed from password hashing happening in two places — `auth.service.ts` hashed the password explicitly with `bcrypt.hash()` before calling `UserModel.create()`, while `users.model.ts` had a `pre('save')` hook that hashed `passwordHash` again if modified, resulting in a double-hashed value that could never be verified at login. The fix adopts **Option A**: the pre-save hook and its `bcrypt` import were removed from `users.model.ts` entirely, making the service layer the single source of truth for hashing. `acceptInvitation` in `users.service.ts` was updated to hash the raw password before `create()` (it previously stored plaintext), and `createTeamMember` now stores a bcrypt-hashed random 32-byte token instead of an empty string `''`, ensuring `bcrypt.compare(anything, placeholder)` always returns `false` until the user sets a real password via the invitation flow. A new test file (`tests/password-hashing.test.ts`) with 11 tests covering all three flows and login round-trips was added, and two pre-existing mock gaps in `auth.test.ts` and `users.invitation.service.test.ts` were patched — all 27 tests pass.

Close #205  