### PR TITLE
feat: implement and document soft delete functionality for users

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,14 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
+
+## [Unreleased]
+
+### Fixed
+- `DELETE /api/users/:id` — replaced raw `res.json()` with `sendResponse()` wrapper in `deleteUserController` for consistent API envelope (#212)
+
+### Added
+- `DELETE /api/users/:id` — added full Swagger spec entry for the soft-delete user endpoint (#212)
+- Integration tests for `DELETE /api/users/:id` covering 200, 401, 403, 400, 404 and SUPER_ADMIN access (#212)

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -497,6 +497,73 @@ paths:
           description: Invalid or expired invitation token
         '409':
           description: Email already in use
+  /api/users/{id}:
+    delete:
+      summary: Delete a user (soft delete)
+      description: Soft-deletes a user by setting deletedAt. Requires ADMIN or SUPER_ADMIN role.
+      security:
+        - bearerAuth: []
+      parameters:
+        - in: path
+          name: id
+          required: true
+          schema:
+            type: string
+          description: MongoDB ObjectId of the user to delete
+      responses:
+        '200':
+          description: User deleted successfully
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                    example: true
+                  message:
+                    type: string
+                    example: User deleted successfully
+                  data:
+                    type: object
+                    properties:
+                      _id:
+                        type: string
+                      email:
+                        type: string
+                      name:
+                        type: string
+                      role:
+                        type: string
+                      organizationId:
+                        type: string
+                      deletedAt:
+                        type: string
+                        format: date-time
+        '400':
+          description: Invalid or missing id parameter
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '401':
+          description: Missing or invalid auth token
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '403':
+          description: Forbidden – insufficient role
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '404':
+          description: User not found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
   /api/analytics/performance:
     get:
       summary: Get analytics performance dashboard

--- a/src/modules/users/users.controller.ts
+++ b/src/modules/users/users.controller.ts
@@ -18,8 +18,8 @@ export const createTeamMemberController: RequestHandler = async (req, res) => {
 };
 
 export const deleteUserController: RequestHandler = async (req, res) => {
-  await usersService.deleteUser(req.params.id);
-  res.json({ success: true, message: 'User deleted successfully' });
+  const result = await usersService.deleteUser(req.params.id);
+  sendResponse(res, 200, true, 'User deleted successfully', result);
 };
 
 export const createInvitationController: RequestHandler = async (req, res) => {

--- a/tests/users.delete.controller.test.ts
+++ b/tests/users.delete.controller.test.ts
@@ -1,0 +1,124 @@
+import { describe, expect, beforeEach, it, jest } from '@jest/globals';
+import request from 'supertest';
+import jwt from 'jsonwebtoken';
+import type { Application } from 'express';
+
+describe('DELETE /api/users/:id', () => {
+  let app: Application;
+
+  const mockDeletedUser = {
+    _id: 'user-to-delete',
+    email: 'target@example.com',
+    organizationId: 'org-a',
+    role: 'VIEWER',
+    deletedAt: new Date().toISOString(),
+  };
+
+  const findByIdAndUpdate = jest.fn<() => Promise<typeof mockDeletedUser | null>>();
+
+  beforeEach(async () => {
+    jest.resetModules();
+    jest.clearAllMocks();
+
+    findByIdAndUpdate.mockResolvedValue(mockDeletedUser);
+
+    await jest.unstable_mockModule('../src/modules/users/users.model.js', () => ({
+      UserModel: { findByIdAndUpdate },
+      OrganizationModel: {},
+      OrganizationType: {},
+      UserRole: {},
+    }));
+
+    await jest.unstable_mockModule('../src/modules/users/users.repo.js', () => ({
+      createUser: jest.fn(),
+      findUserByEmail: jest.fn(),
+      findUsersByOrganizationId: jest.fn(),
+    }));
+
+    const appModule = await import('../src/app.js');
+    app = appModule.buildApp();
+  });
+
+  it('returns standard envelope on successful deletion (ADMIN)', async () => {
+    const token = jwt.sign(
+      { userId: 'admin-1', role: 'ADMIN', organizationId: 'org-a' },
+      process.env.JWT_SECRET!,
+    );
+
+    const res = await request(app)
+      .delete('/api/users/user-to-delete')
+      .set('Authorization', `Bearer ${token}`);
+
+    expect(res.status).toBe(200);
+    expect(res.body.success).toBe(true);
+    expect(typeof res.body.message).toBe('string');
+    expect(res.body.data).toBeDefined();
+    expect(res.body.data._id).toBe('user-to-delete');
+  });
+
+  it('returns 401 when no auth token is provided', async () => {
+    const res = await request(app).delete('/api/users/user-to-delete');
+
+    expect(res.status).toBe(401);
+    expect(res.body.success).toBe(false);
+  });
+
+  it('returns 403 when caller has insufficient role (VIEWER)', async () => {
+    const token = jwt.sign(
+      { userId: 'viewer-1', role: 'VIEWER', organizationId: 'org-a' },
+      process.env.JWT_SECRET!,
+    );
+
+    const res = await request(app)
+      .delete('/api/users/user-to-delete')
+      .set('Authorization', `Bearer ${token}`);
+
+    expect(res.status).toBe(403);
+    expect(String(res.body.message)).toMatch(/forbidden/i);
+  });
+
+  it('returns 400 when id param is empty string', async () => {
+    const token = jwt.sign(
+      { userId: 'admin-1', role: 'ADMIN', organizationId: 'org-a' },
+      process.env.JWT_SECRET!,
+    );
+
+    // Route requires a non-empty :id; an explicit empty segment won't match the route,
+    // so we test a whitespace-only id via the param validator.
+    const res = await request(app)
+      .delete('/api/users/%20')
+      .set('Authorization', `Bearer ${token}`);
+
+    expect(res.status).toBe(400);
+  });
+
+  it('returns 404 when the target user does not exist', async () => {
+    findByIdAndUpdate.mockResolvedValue(null);
+
+    const token = jwt.sign(
+      { userId: 'admin-1', role: 'ADMIN', organizationId: 'org-a' },
+      process.env.JWT_SECRET!,
+    );
+
+    const res = await request(app)
+      .delete('/api/users/nonexistent-id')
+      .set('Authorization', `Bearer ${token}`);
+
+    expect(res.status).toBe(404);
+    expect(res.body.success).toBe(false);
+  });
+
+  it('SUPER_ADMIN can also delete users', async () => {
+    const token = jwt.sign(
+      { userId: 'super-1', role: 'SUPER_ADMIN', organizationId: 'org-a' },
+      process.env.JWT_SECRET!,
+    );
+
+    const res = await request(app)
+      .delete('/api/users/user-to-delete')
+      .set('Authorization', `Bearer ${token}`);
+
+    expect(res.status).toBe(200);
+    expect(res.body.success).toBe(true);
+  });
+});


### PR DESCRIPTION
## What was done 

Fixed bug #212 by replacing the raw `res.json({ success: true, message: 'User deleted successfully' })` call in `deleteUserController` (`users.controller.ts` L22) with the standard `sendResponse(res, 200, true, 'User deleted successfully', result)` wrapper — also capturing the return value from `usersService.deleteUser()` so the deleted user record is included in the response `data` field. Alongside the one-line fix, a new test file (`tests/users.delete.controller.test.ts`) was added with 6 integration tests covering the happy path (ADMIN and SUPER_ADMIN), 401 (no token), 403 (VIEWER role), 400 (blank id param), and 404 (user not found) — all 6 pass with no regressions in the wider user test suites. The previously undocumented `DELETE /api/users/{id}` endpoint was also added to `docs/swagger.yaml` with the full standard-envelope response schema, `bearerAuth` security, and all expected error codes, and a `CHANGELOG.md` was created to record the fix.

Close #212